### PR TITLE
test: add mutation testing with 100% msi threshold

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,3 +46,38 @@ jobs:
 
     - name: Unit Tests
       run: composer test:unit
+
+  mutation:
+    runs-on: ubuntu-latest
+
+    name: Mutation Tests P8.5
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
+      with:
+        php-version: 8.5
+        extensions: dom, mbstring, zip
+        coverage: pcov
+
+    - name: Get Composer cache directory
+      id: composer-cache
+      shell: bash
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+    - name: Cache dependencies
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: ${{ steps.composer-cache.outputs.dir }}
+        key: dependencies-php-8.5-os-ubuntu-latest-version-prefer-stable-composer-${{ hashFiles('composer.json') }}
+        restore-keys: dependencies-php-8.5-os-ubuntu-latest-version-prefer-stable-composer-
+
+    - name: Install Composer dependencies
+      run: composer update --prefer-stable --no-interaction --prefer-dist
+
+    - name: Mutation Tests
+      run: composer test:mutate

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     },
     "require-dev": {
         "laravel/pint": "^1.29.1",
-        "pestphp/pest": "^5.0.0",
-        "pestphp/pest-plugin-type-coverage": "^5.0.0",
+        "pestphp/pest": "^4.0.0",
+        "pestphp/pest-plugin-type-coverage": "^4.0.0",
         "phpstan/phpstan": "^2.1.54",
         "rector/rector": "^2.4.2",
         "symfony/var-dumper": "^8.0.8"
@@ -52,6 +52,7 @@
             "rector --dry-run"
         ],
         "test:unit": "pest --parallel --coverage --exactly=100",
+        "test:mutate": "pest --mutate --parallel --covered-only --min=100",
         "test:types": "phpstan",
         "test:profanity": "pest --profanity",
         "test": [
@@ -59,7 +60,8 @@
             "@test:lint",
             "@test:types",
             "@test:unit",
-            "@test:type-coverage"
+            "@test:type-coverage",
+            "@test:mutate"
         ]
     }
 }

--- a/src/Dto/PlayerSummary.php
+++ b/src/Dto/PlayerSummary.php
@@ -72,7 +72,7 @@ final readonly class PlayerSummary
             avatarFullUrl: $payload['avatarfull'],
             avatarHash: $payload['avatarhash'],
             communityVisibility: CommunityVisibility::fromApiValue($payload['communityvisibilitystate']),
-            hasCommunityProfile: ($payload['profilestate'] ?? 0) === 1,
+            hasCommunityProfile: isset($payload['profilestate']) && $payload['profilestate'] === 1,
             commentPermission: CommentPermission::fromApiValue($payload['commentpermission'] ?? null),
             personaState: PersonaState::from($payload['personastate'] ?? 0),
             realName: $payload['realname'] ?? null,

--- a/src/Http/Requests/GetPlayerSummariesRequest.php
+++ b/src/Http/Requests/GetPlayerSummariesRequest.php
@@ -84,7 +84,7 @@ final class GetPlayerSummariesRequest extends Request
     protected function defaultQuery(): array
     {
         return [
-            'steamids' => implode(',', array_map(static fn (SteamId $id): string => $id->value, $this->steamIds)),
+            'steamids' => implode(',', $this->steamIds),
         ];
     }
 }

--- a/src/ValueObjects/SteamId.php
+++ b/src/ValueObjects/SteamId.php
@@ -37,10 +37,6 @@ final readonly class SteamId implements Stringable
     {
         $input = trim($input);
 
-        if ($input === '') {
-            return null;
-        }
-
         if (preg_match(self::STEAM_ID_64_PATTERN, $input) === 1) {
             return new self($input);
         }

--- a/tests/Feature/Http/Requests/GetOwnedGamesRequestTest.php
+++ b/tests/Feature/Http/Requests/GetOwnedGamesRequestTest.php
@@ -11,6 +11,8 @@ use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 
+covers([GetOwnedGamesRequest::class, OwnedGame::class]);
+
 function ownedGamesConnector(): SteamConnector
 {
     return new SteamConnector(new SteamConfig('test-key'));
@@ -54,6 +56,23 @@ test('query includes optional flags when true', function (): void {
 
     expect($request->query()->all())
         ->toMatchArray(['include_appinfo' => 1, 'include_played_free_games' => 1]);
+});
+
+test('query omits optional flags by default', function (): void {
+    $request = new GetOwnedGamesRequest(testSteamId());
+
+    expect($request->query()->all())
+        ->not->toHaveKey('include_appinfo')
+        ->not->toHaveKey('include_played_free_games');
+});
+
+test('OwnedGame defaults hasCommunityVisibleStats to false when key absent', function (): void {
+    $game = OwnedGame::fromArray([
+        'appid' => 1,
+        'playtime_forever' => 0,
+    ]);
+
+    expect($game->hasCommunityVisibleStats)->toBeFalse();
 });
 
 test('fixture response parses into OwnedGame DTOs', function (): void {

--- a/tests/Feature/Http/Requests/GetPlayerAchievementsRequestTest.php
+++ b/tests/Feature/Http/Requests/GetPlayerAchievementsRequestTest.php
@@ -12,6 +12,8 @@ use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 
+covers([GetPlayerAchievementsRequest::class, PlayerAchievements::class, PlayerAchievement::class]);
+
 function playerAchievementsConnector(): SteamConnector
 {
     return new SteamConnector(new SteamConfig('test-key'));

--- a/tests/Feature/Http/Requests/GetPlayerSummariesRequestTest.php
+++ b/tests/Feature/Http/Requests/GetPlayerSummariesRequestTest.php
@@ -14,6 +14,8 @@ use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 
+covers([GetPlayerSummariesRequest::class, PlayerSummary::class, TooManySteamIdsException::class]);
+
 function summariesConnector(): SteamConnector
 {
     return new SteamConnector(new SteamConfig('test-key'));
@@ -31,6 +33,40 @@ function makeSteamIds(int $count): array
         range(0, $count - 1),
     );
 }
+
+test('PlayerSummary defaults profilestate and personastate when keys absent', function (): void {
+    $summary = PlayerSummary::fromArray([
+        'steamid' => '76561198000000000',
+        'personaname' => 'x',
+        'profileurl' => 'u',
+        'avatar' => 'a',
+        'avatarmedium' => 'am',
+        'avatarfull' => 'af',
+        'avatarhash' => 'h',
+        'communityvisibilitystate' => 3,
+        'timecreated' => 1407003640,
+    ]);
+
+    expect($summary->hasCommunityProfile)->toBeFalse()
+        ->and($summary->personaState)->toBe(PersonaState::Offline);
+});
+
+test('PlayerSummary marks hasCommunityProfile false when profilestate is not 1', function (): void {
+    $summary = PlayerSummary::fromArray([
+        'steamid' => '76561198000000000',
+        'personaname' => 'x',
+        'profileurl' => 'u',
+        'avatar' => 'a',
+        'avatarmedium' => 'am',
+        'avatarfull' => 'af',
+        'avatarhash' => 'h',
+        'communityvisibilitystate' => 3,
+        'profilestate' => 2,
+        'timecreated' => 1407003640,
+    ]);
+
+    expect($summary->hasCommunityProfile)->toBeFalse();
+});
 
 test('endpoint targets GetPlayerSummaries v2', function (): void {
     $request = new GetPlayerSummariesRequest(makeSteamIds(1));

--- a/tests/Feature/Http/Requests/GetUserStatsForGameRequestTest.php
+++ b/tests/Feature/Http/Requests/GetUserStatsForGameRequestTest.php
@@ -13,6 +13,8 @@ use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 
+covers([GetUserStatsForGameRequest::class, UserStats::class, UserStat::class, UserStatAchievement::class]);
+
 function userStatsConnector(): SteamConnector
 {
     return new SteamConnector(new SteamConfig('test-key'));

--- a/tests/Feature/Http/Requests/ResolveVanityUrlRequestTest.php
+++ b/tests/Feature/Http/Requests/ResolveVanityUrlRequestTest.php
@@ -10,6 +10,8 @@ use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 
+covers([ResolveVanityUrlRequest::class, SteamUserNotFoundException::class]);
+
 function connector(): SteamConnector
 {
     return new SteamConnector(new SteamConfig('test-key'));
@@ -51,4 +53,18 @@ test('not-found response throws SteamUserNotFoundException', function (): void {
 
     expect(fn (): mixed => $connector->send(new ResolveVanityUrlRequest('missingUser'))->dto())
         ->toThrow(SteamUserNotFoundException::class, 'No Steam user found for vanity name "missingUser".');
+});
+
+test('non-success code with a steamid present still throws not found', function (): void {
+    $mock = new MockClient([
+        ResolveVanityUrlRequest::class => MockResponse::make([
+            'response' => ['success' => 42, 'steamid' => '76561198000000000'],
+        ]),
+    ]);
+
+    $connector = connector();
+    $connector->withMockClient($mock);
+
+    expect(fn (): mixed => $connector->send(new ResolveVanityUrlRequest('missingUser'))->dto())
+        ->toThrow(SteamUserNotFoundException::class);
 });

--- a/tests/Feature/RateLimitTest.php
+++ b/tests/Feature/RateLimitTest.php
@@ -11,6 +11,8 @@ use Saloon\Http\Faking\MockResponse;
 use Saloon\RateLimitPlugin\Limit;
 use Saloon\RateLimitPlugin\Stores\MemoryStore;
 
+covers([SteamRateLimitException::class, SteamConnector::class]);
+
 beforeEach(function (): void {
     MemoryStore::clear();
 });

--- a/tests/Feature/SteamConnectorTest.php
+++ b/tests/Feature/SteamConnectorTest.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 use Fkrzski\SteamApiSdk\SteamConfig;
 use Fkrzski\SteamApiSdk\SteamConnector;
+use Saloon\RateLimitPlugin\Limit;
+use Saloon\RateLimitPlugin\Stores\MemoryStore;
 use Saloon\Traits\Plugins\AlwaysThrowOnErrors;
+
+covers(SteamConnector::class);
 
 test('base URL resolves to Steam Web API host', function (): void {
     $connector = new SteamConnector(new SteamConfig('any'));
@@ -20,4 +24,31 @@ test('default query carries api key', function (): void {
 
 test('connector uses AlwaysThrowOnErrors plugin', function (): void {
     expect(in_array(AlwaysThrowOnErrors::class, class_uses(SteamConnector::class), true))->toBeTrue();
+});
+
+test('resolveLimits exposes a single 100,000 requests-per-day limit', function (): void {
+    $connector = new SteamConnector(new SteamConfig('any'));
+
+    /** @var array<Limit> $limits */
+    $limits = $connector->getLimits();
+
+    expect($limits)->toHaveCount(2)
+        ->and($limits[0]->getAllow())->toBe(100_000);
+});
+
+test('resolveRateLimitStore returns the store configured on SteamConfig', function (): void {
+    $store = new MemoryStore;
+    $connector = new SteamConnector(new SteamConfig('any', $store));
+
+    $rateLimitStore = $connector->rateLimitStore();
+
+    expect($rateLimitStore)->toBe($store);
+});
+
+test('resolveRateLimitStore falls back to a fresh in-memory store', function (): void {
+    $connector = new SteamConnector(new SteamConfig('any'));
+
+    $rateLimitStore = $connector->rateLimitStore();
+
+    expect($rateLimitStore)->toBeInstanceOf(MemoryStore::class);
 });

--- a/tests/Unit/Enums/CommentPermissionTest.php
+++ b/tests/Unit/Enums/CommentPermissionTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Fkrzski\SteamApiSdk\Enums\CommentPermission;
 
+covers(CommentPermission::class);
+
 test('maps API integer values to enum cases', function (?int $value, CommentPermission $expected): void {
     expect(CommentPermission::fromApiValue($value))->toBe($expected);
 })->with([

--- a/tests/Unit/Enums/CommunityVisibilityTest.php
+++ b/tests/Unit/Enums/CommunityVisibilityTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Fkrzski\SteamApiSdk\Enums\CommunityVisibility;
 
+covers(CommunityVisibility::class);
+
 test('maps API values to enum cases', function (int $value, CommunityVisibility $expected): void {
     expect(CommunityVisibility::fromApiValue($value))->toBe($expected);
 })->with([

--- a/tests/Unit/Enums/PersonaStateTest.php
+++ b/tests/Unit/Enums/PersonaStateTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Fkrzski\SteamApiSdk\Enums\PersonaState;
 
+covers(PersonaState::class);
+
 test('all documented persona state values map to enum cases', function (int $value, PersonaState $expected): void {
     expect(PersonaState::from($value))->toBe($expected);
 })->with([

--- a/tests/Unit/SteamConfigTest.php
+++ b/tests/Unit/SteamConfigTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Fkrzski\SteamApiSdk\SteamConfig;
 
+covers(SteamConfig::class);
+
 test('SteamConfig stores api key', function (): void {
     $config = new SteamConfig(apiKey: 'test-key');
 

--- a/tests/Unit/ValueObjects/SteamIdParsingTest.php
+++ b/tests/Unit/ValueObjects/SteamIdParsingTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use Fkrzski\SteamApiSdk\Exceptions\InvalidSteamIdException;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 
+covers(SteamId::class, InvalidSteamIdException::class);
+
 test('fromSteamId64 accepts a 17-digit numeric string', function (): void {
     $id = SteamId::fromSteamId64('76561198000000000');
 


### PR DESCRIPTION
## Goal

Adds mutation testing based on Pest's built-in `--mutate` and enforces a **Mutation Score Index of 100%** locally and in CI — closing the set of hard quality gates next to 100% line coverage and type coverage.

## Changes

**Configuration**
- new `test:mutate` script: `pest --mutate --parallel --covered-only --min=100`, wired into `composer test`
- dedicated `mutation` job in `tests.yml` (ubuntu, PHP 8.5, pcov) — mutation runs are slow, so we don't multiply them across the full matrix
- `covers()` declared in every test file — in Pest it scopes both mutation generation and coverage accounting

**Pest 5 → 4 downgrade**
- Pest `^4.0` + `pest-plugin-type-coverage ^4.0`
- reason: the Pest 5.x-dev mutate plugin is incompatible with php-code-coverage 14 — it reads the coverage report as an object while the report is now serialized as an array (`Call to a member function getData() on array`)

**Reaching 100% MSI**
- new tests to kill surviving mutants: connector limits and rate-limit store, GetOwnedGames default flags, PlayerSummary defaults, the `success != 1` path in ResolveVanityUrl
- behavior-preserving simplifications surfaced by mutation testing:
  - drop the dead empty-string guard in `SteamId::tryFromInput`
  - drop the redundant `array_map` in `GetPlayerSummariesRequest` (`SteamId` is `Stringable`)
  - rewrite the `profilestate` check in `PlayerSummary` using `isset`

## Verification

`composer test` — all green: profanity, lint (pint+rector), phpstan, unit (100% line coverage), 100% type coverage, **mutation 130 tested / Score 100.00%**.