### PR TITLE
chore: add laravel/pao dev dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "saloonphp/rate-limit-plugin": "^2.0"
     },
     "require-dev": {
+        "laravel/pao": "^1.1",
         "laravel/pint": "^1.29.1",
         "pestphp/pest": "^4.0.0",
         "pestphp/pest-plugin-type-coverage": "^4.0.0",


### PR DESCRIPTION
Adds `laravel/pao` (`^1.1`) as a dev dependency. It provides agent-optimized output for PHP testing tools (Pest/PHPUnit), making test results easier to consume.