### PR TITLE
ci: prevent duplicate workflow runs on pull requests

### DIFF
--- a/.github/workflows/formats.yml
+++ b/.github/workflows/formats.yml
@@ -1,6 +1,9 @@
 name: Formats
 
-on: ['push', 'pull_request']
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,9 @@
 name: Tests
 
-on: ['push', 'pull_request']
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

Workflows (Tests, Mutation, Formats) ran twice for every branch with an open pull request — once for the `push` event and once for the `pull_request` event.

## Fix

Restrict the `push` trigger to the `master` branch only. The `pull_request` trigger still covers every PR.

- Push to `master` → single run
- Any PR → single run