### PR TITLE
chore: improve gitattributes for dist archives and line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,16 +1,25 @@
-/art               export-ignore
-/docs              export-ignore
-/tests             export-ignore
-/scripts           export-ignore
+# Normalize line endings on checkin, force LF on checkout
+* text=auto eol=lf
+
+# Binary files (no diff, no eol munging)
+*.png binary
+
+# GitHub language stats: hide tests, surface src
+/tests             linguist-vendored
+/src               linguist-detectable
+
+# Exclude from `composer install --prefer-dist` archives
 /.github           export-ignore
-/.php_cs           export-ignore
+/art               export-ignore
+/tests             export-ignore
 .editorconfig      export-ignore
 .gitattributes     export-ignore
 .gitignore         export-ignore
-peck.json          export-ignore
 phpstan.neon.dist  export-ignore
 phpunit.xml.dist   export-ignore
 rector.php         export-ignore
 CHANGELOG.md       export-ignore
+CODE_OF_CONDUCT.md export-ignore
 CONTRIBUTING.md    export-ignore
 README.md          export-ignore
+SECURITY.md        export-ignore


### PR DESCRIPTION
## Summary

Cleans up and extends `.gitattributes`.

## Changes

- Normalize line endings (`* text=auto eol=lf`) to avoid CRLF/LF inconsistencies across contributors
- Mark `*.png` as binary (no diff, no eol munging on the banner)
- Add linguist hints so GitHub language stats reflect `src/` and hide `tests/`
- `export-ignore` `CODE_OF_CONDUCT.md` and `SECURITY.md` so they are excluded from `--prefer-dist` archives
- Remove stale entries for paths that no longer exist (`/docs`, `/scripts`, `/.php_cs`, `peck.json`)

`LICENSE.md` is intentionally kept in the distributed package, as required by the MIT license.

## Verification

```
git archive --format=tar HEAD | tar -t
```