### PR TITLE
ci: cache phpstan and rector tools in formats workflow

### DIFF
--- a/.github/workflows/formats.yml
+++ b/.github/workflows/formats.yml
@@ -38,6 +38,13 @@ jobs:
         key: dependencies-php-8.5-os-ubuntu-latest-composer-${{ hashFiles('composer.json') }}
         restore-keys: dependencies-php-8.5-os-ubuntu-latest-composer-
 
+    - name: Cache static analysis tools
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      with:
+        path: .cache
+        key: tools-php-8.5-os-ubuntu-latest-${{ github.run_id }}
+        restore-keys: tools-php-8.5-os-ubuntu-latest-
+
     - name: Install Composer dependencies
       run: composer update --prefer-stable --no-interaction --prefer-dist
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.phpunit.result.cache
 /.phpunit.cache
 /.php-cs-fixer.cache
+/.cache
 /.php-cs-fixer.php
 /composer.lock
 /phpunit.xml

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,6 @@
 parameters:
     level: max
+    tmpDir: .cache/phpstan
     paths:
         - src
 

--- a/rector.php
+++ b/rector.php
@@ -13,6 +13,9 @@ return RectorConfig::configure()
     ->withSkip([
         AddOverrideAttributeToOverriddenMethodsRector::class,
     ])
+    ->withCache(
+        cacheDirectory: __DIR__.'/.cache/rector',
+    )
     ->withPreparedSets(
         deadCode: true,
         codeQuality: true,


### PR DESCRIPTION
## Summary

Persist PHPStan and Rector result caches across CI runs in the Formats workflow. Previously only Composer dependencies were cached, so both static analysis tools ran cold on every run.

## Changes

- `phpstan.neon.dist` — set `tmpDir: .cache/phpstan` so the result cache lives in a deterministic, repo-relative path.
- `rector.php` — add `->withCache(cacheDirectory: __DIR__.'/.cache/rector')`.
- `.gitignore` — ignore `/.cache`.
- `.github/workflows/formats.yml` — add an `actions/cache` step for `.cache`, keyed per run with a prefix `restore-keys` so each run restores the newest cache and saves an updated one.

## Why

Tool result caches default to the runner's ephemeral temp dir and are lost between runs. Pointing them at a fixed path lets `actions/cache` persist them, speeding up `test:types` and `test:lint`.