### PR TITLE
feat: add GetFriendList endpoint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: Setup PHP
-      uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+      uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2
       with:
         php-version: ${{ matrix.php }}
         extensions: dom, mbstring, zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to `php-steam-api-sdk` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `GetFriendList` endpoint (`ISteamUser`) with the `Friend` DTO and `FriendRelationship` enum.
+
 ## [0.2.0] - 2026-06-08
 
 Maintenance release focused on tooling, testing and CI. No user-facing API changes.

--- a/src/Dto/Friend.php
+++ b/src/Dto/Friend.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Dto;
+
+use DateTimeImmutable;
+use Fkrzski\SteamApiSdk\Enums\FriendRelationship;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+
+final readonly class Friend
+{
+    public function __construct(
+        public SteamId $steamId,
+        public FriendRelationship $relationship,
+        public DateTimeImmutable $friendSince,
+    ) {}
+
+    /**
+     * @param  array{
+     *     steamid: string,
+     *     relationship: string,
+     *     friend_since: int,
+     * }  $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        return new self(
+            steamId: SteamId::fromSteamId64($payload['steamid']),
+            relationship: FriendRelationship::from($payload['relationship']),
+            friendSince: (new DateTimeImmutable)->setTimestamp($payload['friend_since']),
+        );
+    }
+}

--- a/src/Enums/FriendRelationship.php
+++ b/src/Enums/FriendRelationship.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Enums;
+
+enum FriendRelationship: string
+{
+    case All = 'all';
+    case Friend = 'friend';
+}

--- a/src/Http/Requests/GetFriendListRequest.php
+++ b/src/Http/Requests/GetFriendListRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Http\Requests;
+
+use Fkrzski\SteamApiSdk\Dto\Friend;
+use Fkrzski\SteamApiSdk\Enums\FriendRelationship;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Override;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+final class GetFriendListRequest extends Request
+{
+    #[Override]
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        public readonly SteamId $steamId,
+        public readonly ?FriendRelationship $relationship = null,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return '/ISteamUser/GetFriendList/v1/';
+    }
+
+    /**
+     * @return list<Friend>
+     */
+    public function createDtoFromResponse(Response $response): array
+    {
+        /**
+         * @var array{friendslist?: array{friends?: list<array{
+         *     steamid: string,
+         *     relationship: string,
+         *     friend_since: int,
+         * }>}} $body
+         */
+        $body = $response->json();
+
+        return array_map(Friend::fromArray(...), $body['friendslist']['friends'] ?? []);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function defaultQuery(): array
+    {
+        $query = ['steamid' => $this->steamId->value];
+
+        if ($this->relationship instanceof FriendRelationship) {
+            $query['relationship'] = $this->relationship->value;
+        }
+
+        return $query;
+    }
+}

--- a/tests/Feature/Http/Requests/GetFriendListRequestTest.php
+++ b/tests/Feature/Http/Requests/GetFriendListRequestTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use Fkrzski\SteamApiSdk\Dto\Friend;
+use Fkrzski\SteamApiSdk\Enums\FriendRelationship;
+use Fkrzski\SteamApiSdk\Http\Requests\GetFriendListRequest;
+use Fkrzski\SteamApiSdk\SteamConfig;
+use Fkrzski\SteamApiSdk\SteamConnector;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+covers([GetFriendListRequest::class, Friend::class]);
+
+function friendListConnector(): SteamConnector
+{
+    return new SteamConnector(new SteamConfig('test-key'));
+}
+
+function friendTestSteamId(): SteamId
+{
+    return SteamId::fromSteamId64('76561198000000000');
+}
+
+test('endpoint targets GetFriendList v1', function (): void {
+    $request = new GetFriendListRequest(friendTestSteamId());
+
+    expect($request->resolveEndpoint())->toBe('/ISteamUser/GetFriendList/v1/');
+});
+
+test('query includes steamid', function (): void {
+    $request = new GetFriendListRequest(friendTestSteamId());
+
+    expect($request->query()->all())->toMatchArray([
+        'steamid' => '76561198000000000',
+    ]);
+});
+
+test('query includes relationship when provided', function (FriendRelationship $relationship, string $expected): void {
+    $request = new GetFriendListRequest(friendTestSteamId(), $relationship);
+
+    expect($request->query()->all())->toMatchArray(['relationship' => $expected]);
+})->with([
+    'all' => [FriendRelationship::All, 'all'],
+    'friend' => [FriendRelationship::Friend, 'friend'],
+]);
+
+test('query omits relationship by default', function (): void {
+    $request = new GetFriendListRequest(friendTestSteamId());
+
+    expect($request->query()->all())->not->toHaveKey('relationship');
+});
+
+test('fixture response parses into Friend DTOs', function (): void {
+    $mock = new MockClient([
+        GetFriendListRequest::class => MockResponse::fixture('get_friend_list'),
+    ]);
+
+    $connector = friendListConnector();
+    $connector->withMockClient($mock);
+
+    /** @var list<Friend> $dtos */
+    $dtos = $connector->send(new GetFriendListRequest(friendTestSteamId(), FriendRelationship::Friend))->dto();
+
+    expect($dtos)->toHaveCount(4)
+        ->and($dtos[0])->toBeInstanceOf(Friend::class)
+        ->and($dtos[0]->steamId)->toBeInstanceOf(SteamId::class)
+        ->and($dtos[0]->steamId->value)->toBe('76561198000408055')
+        ->and($dtos[0]->relationship)->toBe(FriendRelationship::Friend)
+        ->and($dtos[0]->friendSince->getTimestamp())->toBe(1750068880);
+});
+
+test('empty or private fixture returns empty list', function (): void {
+    $mock = new MockClient([
+        GetFriendListRequest::class => MockResponse::fixture('get_friend_list_empty'),
+    ]);
+
+    $connector = friendListConnector();
+    $connector->withMockClient($mock);
+
+    $dtos = $connector->send(new GetFriendListRequest(friendTestSteamId()))->dto();
+
+    expect($dtos)->toBeEmpty();
+});

--- a/tests/Fixtures/Saloon/get_friend_list.json
+++ b/tests/Fixtures/Saloon/get_friend_list.json
@@ -1,0 +1,32 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "friendslist": {
+            "friends": [
+                {
+                    "steamid": "76561198000408055",
+                    "relationship": "friend",
+                    "friend_since": 1750068880
+                },
+                {
+                    "steamid": "76561198076234377",
+                    "relationship": "friend",
+                    "friend_since": 1569950369
+                },
+                {
+                    "steamid": "76561198086432305",
+                    "relationship": "friend",
+                    "friend_since": 1499363198
+                },
+                {
+                    "steamid": "76561198112001746",
+                    "relationship": "friend",
+                    "friend_since": 1548669134
+                }
+            ]
+        }
+    }
+}

--- a/tests/Fixtures/Saloon/get_friend_list_empty.json
+++ b/tests/Fixtures/Saloon/get_friend_list_empty.json
@@ -1,0 +1,7 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {}
+}

--- a/tests/Unit/Enums/FriendRelationshipTest.php
+++ b/tests/Unit/Enums/FriendRelationshipTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Fkrzski\SteamApiSdk\Enums\FriendRelationship;
+
+covers(FriendRelationship::class);
+
+test('all documented relationship values map to enum cases', function (string $value, FriendRelationship $expected): void {
+    expect(FriendRelationship::from($value))->toBe($expected);
+})->with([
+    'all' => ['all', FriendRelationship::All],
+    'friend' => ['friend', FriendRelationship::Friend],
+]);
+
+test('unknown values throw ValueError', function (): void {
+    FriendRelationship::from('unknown');
+})->throws(ValueError::class);


### PR DESCRIPTION
## Summary

Adds the `ISteamUser/GetFriendList` endpoint, closing another item on the road to 0.3.0.

## Changes

- `GetFriendListRequest` — targets `/ISteamUser/GetFriendList/v1/`, with an optional `relationship` filter.
- `Friend` DTO — `SteamId` value object, `FriendRelationship` enum, `friend_since` as `DateTimeImmutable`.
- `FriendRelationship` enum — `all` / `friend`.
- A missing `friendslist` key (empty list or private profile, indistinguishable in the API) resolves to an empty list rather than throwing.

## Tests

- Feature tests for the request (endpoint, query, fixture parsing, empty/private response).
- Unit test for the `FriendRelationship` enum.
- Two new fixtures: populated and empty.

## Quality

- Pest: all green
- PHPStan max: 0 errors
- Pint + Rector: clean
- Mutation (MSI): 100%
- Type coverage: 100%