### PR TITLE
refactor: group request classes by steam interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Reorganize request classes into per-interface subnamespaces (`Http\Requests\ISteamUser`, `Http\Requests\ISteamUserStats`, `Http\Requests\IPlayerService`). Update imports when upgrading.
 - Pin GitHub Actions to version tags instead of commit hashes for readability.
 
 ## [0.2.0] - 2026-06-08

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ composer require fkrzski/php-steam-api-sdk
 ## Quickstart
 
 ```php
-use Fkrzski\SteamApiSdk\Http\Requests\GetPlayerSummariesRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetPlayerSummariesRequest;
 use Fkrzski\SteamApiSdk\SteamConfig;
 use Fkrzski\SteamApiSdk\SteamConnector;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
@@ -68,7 +68,7 @@ $vanity = SteamId::extractVanityName('https://steamcommunity.com/id/gabelogannew
 
 ```php
 use Fkrzski\SteamApiSdk\Exceptions\SteamUserNotFoundException;
-use Fkrzski\SteamApiSdk\Http\Requests\ResolveVanityUrlRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\ResolveVanityUrlRequest;
 
 try {
     $steamId = $connector->send(new ResolveVanityUrlRequest('gabelogannewell'))->dto();
@@ -81,7 +81,7 @@ try {
 
 ```php
 use Fkrzski\SteamApiSdk\Exceptions\TooManySteamIdsException;
-use Fkrzski\SteamApiSdk\Http\Requests\GetPlayerSummariesRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetPlayerSummariesRequest;
 
 $summaries = $connector->send(new GetPlayerSummariesRequest([$steamId]))->dto();
 
@@ -96,7 +96,7 @@ Passing more than 100 IDs throws `TooManySteamIdsException`.
 
 ```php
 use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
-use Fkrzski\SteamApiSdk\Http\Requests\GetOwnedGamesRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetOwnedGamesRequest;
 
 try {
     $library = $connector->send(new GetOwnedGamesRequest(
@@ -113,7 +113,7 @@ try {
 ### User stats for a single game
 
 ```php
-use Fkrzski\SteamApiSdk\Http\Requests\GetUserStatsForGameRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetUserStatsForGameRequest;
 
 $stats = $connector->send(new GetUserStatsForGameRequest(
     steamId: $steamId,
@@ -129,7 +129,7 @@ foreach ($stats->stats as $stat) {
 ### Player achievements
 
 ```php
-use Fkrzski\SteamApiSdk\Http\Requests\GetPlayerAchievementsRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetPlayerAchievementsRequest;
 
 $achievements = $connector->send(new GetPlayerAchievementsRequest(
     steamId: $steamId,

--- a/src/Http/Requests/IPlayerService/GetOwnedGamesRequest.php
+++ b/src/Http/Requests/IPlayerService/GetOwnedGamesRequest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Fkrzski\SteamApiSdk\Http\Requests;
+namespace Fkrzski\SteamApiSdk\Http\Requests\IPlayerService;
 
 use Fkrzski\SteamApiSdk\Dto\OwnedGame;
 use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;

--- a/src/Http/Requests/ISteamUser/GetPlayerSummariesRequest.php
+++ b/src/Http/Requests/ISteamUser/GetPlayerSummariesRequest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Fkrzski\SteamApiSdk\Http\Requests;
+namespace Fkrzski\SteamApiSdk\Http\Requests\ISteamUser;
 
 use Fkrzski\SteamApiSdk\Dto\PlayerSummary;
 use Fkrzski\SteamApiSdk\Exceptions\TooManySteamIdsException;

--- a/src/Http/Requests/ISteamUser/ResolveVanityUrlRequest.php
+++ b/src/Http/Requests/ISteamUser/ResolveVanityUrlRequest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Fkrzski\SteamApiSdk\Http\Requests;
+namespace Fkrzski\SteamApiSdk\Http\Requests\ISteamUser;
 
 use Fkrzski\SteamApiSdk\Exceptions\SteamUserNotFoundException;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;

--- a/src/Http/Requests/ISteamUserStats/GetPlayerAchievementsRequest.php
+++ b/src/Http/Requests/ISteamUserStats/GetPlayerAchievementsRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Fkrzski\SteamApiSdk\Http\Requests;
+namespace Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats;
 
-use Fkrzski\SteamApiSdk\Dto\UserStats;
+use Fkrzski\SteamApiSdk\Dto\PlayerAchievements;
 use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 use Override;
@@ -12,7 +12,7 @@ use Saloon\Enums\Method;
 use Saloon\Http\Request;
 use Saloon\Http\Response;
 
-final class GetUserStatsForGameRequest extends Request
+final class GetPlayerAchievementsRequest extends Request
 {
     #[Override]
     protected Method $method = Method::GET;
@@ -25,26 +25,26 @@ final class GetUserStatsForGameRequest extends Request
 
     public function resolveEndpoint(): string
     {
-        return '/ISteamUserStats/GetUserStatsForGame/v2/';
+        return '/ISteamUserStats/GetPlayerAchievements/v1/';
     }
 
-    public function createDtoFromResponse(Response $response): UserStats
+    public function createDtoFromResponse(Response $response): PlayerAchievements
     {
         /**
          * @var array{playerstats?: array{
          *     steamID: string,
          *     gameName: string,
-         *     stats?: list<array{name: string, value: int|float}>,
-         *     achievements?: list<array{name: string, achieved: int}>,
+         *     achievements: list<array{apiname: string, achieved: int, unlocktime: int, name?: string, description?: string}>,
+         *     success: bool,
          * }} $body
          */
         $body = $response->json();
 
-        if (! array_key_exists('playerstats', $body)) {
+        if (! isset($body['playerstats']['success']) || $body['playerstats']['success'] === false) {
             throw new ProfileNotPublicException('Steam profile is not public.');
         }
 
-        return UserStats::fromArray($body['playerstats']);
+        return PlayerAchievements::fromArray($body['playerstats']);
     }
 
     /**

--- a/src/Http/Requests/ISteamUserStats/GetUserStatsForGameRequest.php
+++ b/src/Http/Requests/ISteamUserStats/GetUserStatsForGameRequest.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Fkrzski\SteamApiSdk\Http\Requests;
+namespace Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats;
 
-use Fkrzski\SteamApiSdk\Dto\PlayerAchievements;
+use Fkrzski\SteamApiSdk\Dto\UserStats;
 use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 use Override;
@@ -12,7 +12,7 @@ use Saloon\Enums\Method;
 use Saloon\Http\Request;
 use Saloon\Http\Response;
 
-final class GetPlayerAchievementsRequest extends Request
+final class GetUserStatsForGameRequest extends Request
 {
     #[Override]
     protected Method $method = Method::GET;
@@ -25,26 +25,26 @@ final class GetPlayerAchievementsRequest extends Request
 
     public function resolveEndpoint(): string
     {
-        return '/ISteamUserStats/GetPlayerAchievements/v1/';
+        return '/ISteamUserStats/GetUserStatsForGame/v2/';
     }
 
-    public function createDtoFromResponse(Response $response): PlayerAchievements
+    public function createDtoFromResponse(Response $response): UserStats
     {
         /**
          * @var array{playerstats?: array{
          *     steamID: string,
          *     gameName: string,
-         *     achievements: list<array{apiname: string, achieved: int, unlocktime: int, name?: string, description?: string}>,
-         *     success: bool,
+         *     stats?: list<array{name: string, value: int|float}>,
+         *     achievements?: list<array{name: string, achieved: int}>,
          * }} $body
          */
         $body = $response->json();
 
-        if (! isset($body['playerstats']['success']) || $body['playerstats']['success'] === false) {
+        if (! array_key_exists('playerstats', $body)) {
             throw new ProfileNotPublicException('Steam profile is not public.');
         }
 
-        return PlayerAchievements::fromArray($body['playerstats']);
+        return UserStats::fromArray($body['playerstats']);
     }
 
     /**

--- a/tests/Feature/Http/Requests/IPlayerService/GetOwnedGamesRequestTest.php
+++ b/tests/Feature/Http/Requests/IPlayerService/GetOwnedGamesRequestTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Fkrzski\SteamApiSdk\Dto\OwnedGame;
 use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
-use Fkrzski\SteamApiSdk\Http\Requests\GetOwnedGamesRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetOwnedGamesRequest;
 use Fkrzski\SteamApiSdk\SteamConfig;
 use Fkrzski\SteamApiSdk\SteamConnector;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;

--- a/tests/Feature/Http/Requests/ISteamUser/GetPlayerSummariesRequestTest.php
+++ b/tests/Feature/Http/Requests/ISteamUser/GetPlayerSummariesRequestTest.php
@@ -7,7 +7,7 @@ use Fkrzski\SteamApiSdk\Enums\CommentPermission;
 use Fkrzski\SteamApiSdk\Enums\CommunityVisibility;
 use Fkrzski\SteamApiSdk\Enums\PersonaState;
 use Fkrzski\SteamApiSdk\Exceptions\TooManySteamIdsException;
-use Fkrzski\SteamApiSdk\Http\Requests\GetPlayerSummariesRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetPlayerSummariesRequest;
 use Fkrzski\SteamApiSdk\SteamConfig;
 use Fkrzski\SteamApiSdk\SteamConnector;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;

--- a/tests/Feature/Http/Requests/ISteamUser/ResolveVanityUrlRequestTest.php
+++ b/tests/Feature/Http/Requests/ISteamUser/ResolveVanityUrlRequestTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Fkrzski\SteamApiSdk\Exceptions\SteamUserNotFoundException;
-use Fkrzski\SteamApiSdk\Http\Requests\ResolveVanityUrlRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\ResolveVanityUrlRequest;
 use Fkrzski\SteamApiSdk\SteamConfig;
 use Fkrzski\SteamApiSdk\SteamConnector;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;

--- a/tests/Feature/Http/Requests/ISteamUserStats/GetPlayerAchievementsRequestTest.php
+++ b/tests/Feature/Http/Requests/ISteamUserStats/GetPlayerAchievementsRequestTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Fkrzski\SteamApiSdk\Dto\PlayerAchievement;
 use Fkrzski\SteamApiSdk\Dto\PlayerAchievements;
 use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
-use Fkrzski\SteamApiSdk\Http\Requests\GetPlayerAchievementsRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetPlayerAchievementsRequest;
 use Fkrzski\SteamApiSdk\SteamConfig;
 use Fkrzski\SteamApiSdk\SteamConnector;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;

--- a/tests/Feature/Http/Requests/ISteamUserStats/GetUserStatsForGameRequestTest.php
+++ b/tests/Feature/Http/Requests/ISteamUserStats/GetUserStatsForGameRequestTest.php
@@ -6,7 +6,7 @@ use Fkrzski\SteamApiSdk\Dto\UserStat;
 use Fkrzski\SteamApiSdk\Dto\UserStatAchievement;
 use Fkrzski\SteamApiSdk\Dto\UserStats;
 use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
-use Fkrzski\SteamApiSdk\Http\Requests\GetUserStatsForGameRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetUserStatsForGameRequest;
 use Fkrzski\SteamApiSdk\SteamConfig;
 use Fkrzski\SteamApiSdk\SteamConnector;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;

--- a/tests/Feature/RateLimitTest.php
+++ b/tests/Feature/RateLimitTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use Fkrzski\SteamApiSdk\Exceptions\SteamRateLimitException;
-use Fkrzski\SteamApiSdk\Http\Requests\ResolveVanityUrlRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\ResolveVanityUrlRequest;
 use Fkrzski\SteamApiSdk\SteamConfig;
 use Fkrzski\SteamApiSdk\SteamConnector;
 use Saloon\Http\Faking\MockClient;


### PR DESCRIPTION
## Summary

Reorganize Saloon request classes into per-interface subnamespaces to keep the `Http/Requests` directory manageable as more Steam endpoints are added. The folder structure now mirrors the Steam Web API 1:1.

## Mapping

| Subnamespace | Requests |
|---|---|
| `Http\Requests\ISteamUser` | `GetPlayerSummariesRequest`, `ResolveVanityUrlRequest` |
| `Http\Requests\ISteamUserStats` | `GetUserStatsForGameRequest`, `GetPlayerAchievementsRequest` |
| `Http\Requests\IPlayerService` | `GetOwnedGamesRequest` |

## Changes

- Moved request classes (via `git mv`, history preserved) and updated their namespaces.
- Mirrored the layout in `tests/Feature/Http/Requests/` and updated request imports across the test suite.
- Updated request `use` statements in the README.
- Added a `Changed` entry to the changelog.

## Breaking change

Namespaces of request classes changed. Consumers importing them directly must update their imports. Acceptable on `0.x` (pre-1.0).

## Verification

- Pest: 94 passed (195 assertions)
- PHPStan: 0 errors
- Rector (dry-run): 0 changes
- Pint: passed