### PR TITLE
fix: parse Steam URLs with a trailing path, query or fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `SteamId::tryFromInput()` and `SteamId::extractVanityName()` now parse profile and vanity URLs that carry a sub-path, query string or fragment (e.g. `/profiles/<id>/stats/`, `/id/<nick>?snr=…`). Previously the trailing segment made `tryFromInput()` return `null`, while `extractVanityName()` silently returned an unusable slug.
+
 ## [0.3.0] - 2026-07-30
 
 ### Added

--- a/src/ValueObjects/SteamId.php
+++ b/src/ValueObjects/SteamId.php
@@ -11,9 +11,9 @@ final readonly class SteamId implements Stringable
 {
     private const string STEAM_ID_64_PATTERN = '/^\d{17}$/';
 
-    private const string PROFILE_URL_PATTERN = '#/profiles/(\d{17})/?$#';
+    private const string PROFILE_URL_PATTERN = '#/profiles/(\d{17})(?:[/?\#]|$)#';
 
-    private const string VANITY_URL_PATTERN = '#/id/([^/]+)/?$#';
+    private const string VANITY_URL_PATTERN = '#/id/([^/?\#]+)#';
 
     private function __construct(
         public string $value,

--- a/tests/Unit/ValueObjects/SteamIdParsingTest.php
+++ b/tests/Unit/ValueObjects/SteamIdParsingTest.php
@@ -39,11 +39,16 @@ test('tryFromInput parses numeric and profile URL inputs', function (string $inp
     'plain 17-digit' => ['76561198000000000', '76561198000000000'],
     'profile URL' => ['https://steamcommunity.com/profiles/76561198000000000', '76561198000000000'],
     'profile URL trailing slash' => ['https://steamcommunity.com/profiles/76561198000000000/', '76561198000000000'],
+    'profile URL sub-path' => ['https://steamcommunity.com/profiles/76561198000000000/stats/', '76561198000000000'],
+    'profile URL query string' => ['https://steamcommunity.com/profiles/76561198000000000?snr=1_4_4__12', '76561198000000000'],
+    'profile URL fragment' => ['https://steamcommunity.com/profiles/76561198000000000#comments', '76561198000000000'],
     'whitespace padded numeric' => ['  76561198000000000  ', '76561198000000000'],
     'vanity URL → null' => ['https://steamcommunity.com/id/gabelogannewell', null],
     'bare vanity → null' => ['gabelogannewell', null],
     'empty → null' => ['', null],
     'too short numeric → null' => ['1234567890', null],
+    'profile URL with over-long digit run → null' => ['https://steamcommunity.com/profiles/765611980000000001234', null],
+    'profile URL with letters after ID → null' => ['https://steamcommunity.com/profiles/76561198000000000abc', null],
 ]);
 
 test('extractVanityName pulls slug from id-URL, else returns input', function (string $input, string $expected): void {
@@ -51,6 +56,9 @@ test('extractVanityName pulls slug from id-URL, else returns input', function (s
 })->with([
     'vanity URL' => ['https://steamcommunity.com/id/gabelogannewell', 'gabelogannewell'],
     'vanity URL trailing slash' => ['https://steamcommunity.com/id/gabelogannewell/', 'gabelogannewell'],
+    'vanity URL sub-path' => ['https://steamcommunity.com/id/gabelogannewell/screenshots/', 'gabelogannewell'],
+    'vanity URL query string' => ['https://steamcommunity.com/id/gabelogannewell?snr=1_4_4__12', 'gabelogannewell'],
+    'vanity URL fragment' => ['https://steamcommunity.com/id/gabelogannewell#comments', 'gabelogannewell'],
     'bare nick' => ['gabelogannewell', 'gabelogannewell'],
     'nick with spaces' => ['  someUser  ', 'someUser'],
 ]);


### PR DESCRIPTION
## Summary

`SteamId::tryFromInput()` returned `null` for any profile URL where something followed the 17-digit ID — a sub-path, a query string or a fragment. `SteamId::extractVanityName()` had the same flaw and failed worse, silently returning an unusable slug instead of the nick. Both patterns now end the capture at a path/query/fragment boundary rather than requiring end of string.

Fixes #23.

## Why

These are the URLs Steam itself generates and that users copy out of the address bar — `/stats/`, `/screenshots/`, `?snr=1_4_4__12`. The contract of `tryFromInput()` is "extract an ID from whatever a human pasted": the ID was present in the string and the regex matched it, only for the `$` anchor to discard it because of the trailing segment.

For `extractVanityName()` the old pattern returned `gabelogannewell?snr=1_4_4__12` for a query-string URL and the entire URL for a sub-path one. That is worse than a `null`, because the caller gets something that looks like a nick and the error only surfaces later as an empty response from `ResolveVanityURL`.

## Changes

| Constant | Before | After |
|---|---|---|
| `PROFILE_URL_PATTERN` | `#/profiles/(\d{17})/?$#` | `#/profiles/(\d{17})(?:[/?\#]|$)#` |
| `VANITY_URL_PATTERN` | `#/id/([^/]+)/?$#` | `#/id/([^/?\#]+)#` |

- The `#` inside the character class must stay escaped. With a bare `#`, PHP terminates the pattern at the delimiter before the class closes and `preg_match()` fails with `Internal error` instead of matching.
- Validation of the ID itself is unchanged: `\d{17}` remains anchored immediately after `/profiles/`, so it cannot slide along a longer digit run. Two negative cases guard this.
- Test datasets gain sub-path, query-string and fragment variants for both methods, plus the two negative cases for `tryFromInput`.
- Changelog entry under `[Unreleased]`.

## Verification

- `composer test:unit` — 112 passed, 100% coverage
- `composer test:types` — PHPStan max, 0 errors
- `composer test:type-coverage` — 100%
- `composer test:mutate` — 138 mutations, score 100%
- Pint — passed

`composer test:lint` cannot complete: Rector crashes on startup with `MissingPrivatePropertyException: Property "$container" was not found in "PHPStan\Parser\RichParser"`. This is pre-existing on `master` (verified at 4cba46f with this branch's changes stashed) — the pin from 25bfc31 was undone by #22 — and is unrelated to this PR.
