### PR TITLE
fix: back CommentPermission and CommunityVisibility enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BC break.** `CommentPermission` and `CommunityVisibility` are now backed enums. `CommunityVisibility` is backed by `int` using Steam's own `communityvisibilitystate` codes (`Hidden = 1`, `Visible = 3`); `CommentPermission` is backed by `string` (`'everyone'`, `'nobody'`, `'friends_only'`), because Steam omits the `commentpermission` key entirely for the friends-only case and so has no wire integer for it. Case names are unchanged and `fromApiValue()` keeps its signature and its `UnexpectedValueException` on unknown input — only code that relies on these being pure enums (a `UnitEnum` type hint, or `instanceof UnitEnum` checks) needs updating.
+
 ### Fixed
 
+- `PlayerSummary` can now be passed to `json_encode()`. Both enums it exposes were pure, and PHP has no default serialization for those, so encoding a `PlayerSummary` — or any structure containing one — returned `false` with `Non-backed enums have no default serialization`. See [#25](https://github.com/fkrzski/php-steam-api-sdk/issues/25); `DateTimeImmutable` properties still serialize as PHP's internal shape and remain open there.
 - `SteamId::tryFromInput()` and `SteamId::extractVanityName()` now parse profile and vanity URLs that carry a sub-path, query string or fragment (e.g. `/profiles/<id>/stats/`, `/id/<nick>?snr=…`). Previously the trailing segment made `tryFromInput()` return `null`, while `extractVanityName()` silently returned an unusable slug.
 
 ## [0.3.0] - 2026-07-30

--- a/docs/dto-reference.md
+++ b/docs/dto-reference.md
@@ -106,8 +106,13 @@ Each `PlayerAchievement` carries:
 | `LookingToTrade` | `5` |
 | `LookingToPlay` | `6` |
 
-`CommunityVisibility` — `Hidden`, `Visible`.
+`CommunityVisibility` (backed by `int`) — `Hidden` (`1`), `Visible` (`3`). The backing
+values are Steam's own `communityvisibilitystate` codes.
 
-`CommentPermission` — `Everyone`, `Nobody`, `FriendsOnly`.
+`CommentPermission` (backed by `string`) — `Everyone` (`'everyone'`), `Nobody`
+(`'nobody'`), `FriendsOnly` (`'friends_only'`). Steam sends `commentpermission` as an
+integer and omits the key entirely for the friends-only case, so these backing values
+are the SDK's own vocabulary rather than the wire values. Use `fromApiValue()` to map
+from the raw API payload.
 
 `FriendRelationship` (backed by `string`) — `All` (`'all'`), `Friend` (`'friend'`).

--- a/src/Enums/CommentPermission.php
+++ b/src/Enums/CommentPermission.php
@@ -6,11 +6,11 @@ namespace Fkrzski\SteamApiSdk\Enums;
 
 use UnexpectedValueException;
 
-enum CommentPermission
+enum CommentPermission: string
 {
-    case Everyone;
-    case Nobody;
-    case FriendsOnly;
+    case Everyone = 'everyone';
+    case Nobody = 'nobody';
+    case FriendsOnly = 'friends_only';
 
     public static function fromApiValue(?int $value): self
     {

--- a/src/Enums/CommunityVisibility.php
+++ b/src/Enums/CommunityVisibility.php
@@ -6,17 +6,14 @@ namespace Fkrzski\SteamApiSdk\Enums;
 
 use UnexpectedValueException;
 
-enum CommunityVisibility
+enum CommunityVisibility: int
 {
-    case Hidden;
-    case Visible;
+    case Hidden = 1;
+    case Visible = 3;
 
     public static function fromApiValue(int $value): self
     {
-        return match ($value) {
-            1 => self::Hidden,
-            3 => self::Visible,
-            default => throw new UnexpectedValueException(sprintf('Unknown communityvisibilitystate value "%d".', $value)),
-        };
+        return self::tryFrom($value)
+            ?? throw new UnexpectedValueException(sprintf('Unknown communityvisibilitystate value "%d".', $value));
     }
 }

--- a/tests/Unit/Enums/CommentPermissionTest.php
+++ b/tests/Unit/Enums/CommentPermissionTest.php
@@ -17,3 +17,10 @@ test('maps API integer values to enum cases', function (?int $value, CommentPerm
 test('unknown values throw UnexpectedValueException', function (): void {
     CommentPermission::fromApiValue(7);
 })->throws(UnexpectedValueException::class, 'Unknown commentpermission value "7".');
+
+test('backing values are stable tokens and survive json_encode', function (): void {
+    expect(CommentPermission::Everyone->value)->toBe('everyone')
+        ->and(CommentPermission::Nobody->value)->toBe('nobody')
+        ->and(CommentPermission::FriendsOnly->value)->toBe('friends_only')
+        ->and(json_encode(CommentPermission::FriendsOnly, JSON_THROW_ON_ERROR))->toBe('"friends_only"');
+});

--- a/tests/Unit/Enums/CommunityVisibilityTest.php
+++ b/tests/Unit/Enums/CommunityVisibilityTest.php
@@ -16,3 +16,9 @@ test('maps API values to enum cases', function (int $value, CommunityVisibility 
 test('unknown values throw UnexpectedValueException', function (): void {
     CommunityVisibility::fromApiValue(2);
 })->throws(UnexpectedValueException::class, 'Unknown communityvisibilitystate value "2".');
+
+test('backing values mirror the API and survive json_encode', function (): void {
+    expect(CommunityVisibility::Hidden->value)->toBe(1)
+        ->and(CommunityVisibility::Visible->value)->toBe(3)
+        ->and(json_encode(CommunityVisibility::Visible, JSON_THROW_ON_ERROR))->toBe('3');
+});


### PR DESCRIPTION
## Summary

`CommentPermission` and `CommunityVisibility` were pure enums, and PHP has no default serialization for those. Any `json_encode()` reaching a `PlayerSummary` aborted the entire encode and returned `false` with `Non-backed enums have no default serialization` — an API response, a cache write, a Livewire payload, a queued job argument. Both enums now carry a backing type.

Refs #25. **Does not close it** — the enum failure is fixed, but the `DateTimeImmutable` half of that issue is untouched and the round-trip question is still open.

## Why the two backing types differ

`CommunityVisibility` is backed by `int` with Steam's own `communityvisibilitystate` codes, matching the rule the codebase already follows in `PersonaState: int` and `FriendRelationship: string` — the backing value is the wire value.

That rule cannot hold for `CommentPermission`. Steam sends `commentpermission` as an integer but **omits the key entirely** when only friends may comment, so `FriendsOnly` has no wire integer at all. The alternative was a synthetic sentinel (`0`), which puts a value the API never sends into Steam's own namespace and would collide silently if Steam later assigns it a meaning. The backing values are therefore the SDK's own vocabulary, and `fromApiValue()` remains the adapter from the raw payload. The reasoning sits in a docblock on the method so it is not later "unified" by mistake.

## Changes

| Enum | Before | After |
|---|---|---|
| `CommunityVisibility` | pure | `: int` — `Hidden = 1`, `Visible = 3` |
| `CommentPermission` | pure | `: string` — `'everyone'`, `'nobody'`, `'friends_only'` |

- `CommunityVisibility::fromApiValue()` collapses to `tryFrom() ?? throw`, keeping its signature and its `UnexpectedValueException` on unknown input. `CommentPermission::fromApiValue()` keeps its `match`, since `null` maps to a case.
- Case names are unchanged. **BC break** limited to code that relies on these being pure — a `UnitEnum` type hint, or `instanceof UnitEnum`.
- Tests lock the backing values and assert both enums survive `json_encode()`.
- Changelog entry under `[Unreleased]` (`Changed` + `Fixed`) and updated enum tables in `docs/dto-reference.md`.

## What this does not fix

`PlayerSummary` now encodes, but not yet to a shape worth publishing:

```json
{"steamId":{"value":"76561198000000000"}, …,
 "communityVisibility":3, "commentPermission":"friends_only", …,
 "timeCreated":{"date":"2001-09-09 01:46:40.000000","timezone_type":3,"timezone":"UTC"}}
```

`DateTimeImmutable` still leaks PHP's internal shape in `PlayerSummary::$timeCreated`, `PlayerSummary::$lastLogOff`, `Friend::$friendSince` and `PlayerAchievement::$unlockedAt`; `SteamId` still encodes as a nested object. Both remain open in #25.

## Verification

- `composer test:lint` — Pint and Rector passed
- `composer test:types` — PHPStan, 0 errors
- `composer test:unit` — 114 passed, 100% coverage
- `composer test:type-coverage` — 100%
- `composer test:mutate` — 138 mutations, score 100%
