### PR TITLE
feat: implement JsonSerializable on SteamId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `SteamId` now implements `JsonSerializable` and encodes to a bare string. Previously `json_encode()` emitted `{"value":"<id>"}`, since the promoted `value` property is public. Part of [#25](https://github.com/fkrzski/php-steam-api-sdk/issues/25); `DateTimeImmutable` properties on the DTOs still serialize as PHP's internal shape and remain open there.
+
 ### Fixed
 
 - `SteamId::tryFromInput()` and `SteamId::extractVanityName()` now parse profile and vanity URLs that carry a sub-path, query string or fragment (e.g. `/profiles/<id>/stats/`, `/id/<nick>?snr=…`). Previously the trailing segment made `tryFromInput()` return `null`, while `extractVanityName()` silently returned an unusable slug.

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -28,6 +28,11 @@ $vanity = SteamId::extractVanityName('https://steamcommunity.com/id/gabelogannew
 The underlying value is available as `$id->value` (or `(string) $id`), and two IDs
 compare with `$id->equals($other)`.
 
+`SteamId` implements `JsonSerializable`, so it encodes as a bare string —
+`json_encode(['steam_id' => $id])` yields `{"steam_id":"76561198000000000"}`, not a
+nested object. Decoding is not symmetric: rebuild the value object with
+`SteamId::fromSteamId64()` on the way back.
+
 ## Sending requests
 
 Every request is a plain Saloon `Request`. Send it through the connector and call

--- a/src/ValueObjects/SteamId.php
+++ b/src/ValueObjects/SteamId.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Fkrzski\SteamApiSdk\ValueObjects;
 
 use Fkrzski\SteamApiSdk\Exceptions\InvalidSteamIdException;
+use JsonSerializable;
 use Stringable;
 
-final readonly class SteamId implements Stringable
+final readonly class SteamId implements JsonSerializable, Stringable
 {
     private const string STEAM_ID_64_PATTERN = '/^\d{17}$/';
 
@@ -20,6 +21,11 @@ final readonly class SteamId implements Stringable
     ) {}
 
     public function __toString(): string
+    {
+        return $this->value;
+    }
+
+    public function jsonSerialize(): string
     {
         return $this->value;
     }

--- a/tests/Unit/ValueObjects/SteamIdParsingTest.php
+++ b/tests/Unit/ValueObjects/SteamIdParsingTest.php
@@ -71,3 +71,11 @@ test('equals compares by value', function (): void {
     expect($a->equals($b))->toBeTrue()
         ->and($a->equals($c))->toBeFalse();
 });
+
+test('jsonSerialize encodes to a bare string, not an object', function (): void {
+    $id = SteamId::fromSteamId64('76561198000000000');
+
+    expect($id->jsonSerialize())->toBe('76561198000000000')
+        ->and(json_encode($id, JSON_THROW_ON_ERROR))->toBe('"76561198000000000"')
+        ->and(json_encode(['steam_id' => $id], JSON_THROW_ON_ERROR))->toBe('{"steam_id":"76561198000000000"}');
+});


### PR DESCRIPTION
## Summary

`SteamId` implements `JsonSerializable` and encodes to a bare string. Previously `json_encode()` fell back to reflecting over public properties and emitted `{"value":"76561198000000000"}`, because the promoted `value` property is public.

Part of #25. **Does not close it** — this covers only the `SteamId` half; `DateTimeImmutable` still serializes as PHP's internal shape, and the round-trip question is still open there.

## Why

The value object already implements `Stringable`, so interpolation, concatenation, `sprintf('%s')` and array keys all yield the ID. JSON was the one path that leaked the internal property name into the output, which makes the wire shape hostage to a field rename: if `$value` is ever renamed, every consumer breaks silently. A bare string is the only sensible representation of a value object wrapping exactly one string, and it is what every other scalar VO does.

Serialization stays one-way by design. `SteamId` holds a single string, so nothing is lost — coming back is `SteamId::fromSteamId64($decoded['steam_id'])`, and a `fromJson()` would be a pure alias for it. PHP has no `JsonDeserializable` counterpart, so nothing would call such a method automatically anyway; frameworks that hydrate value objects (an Eloquent cast, a Livewire Synth) call `fromSteamId64()` directly and need nothing from this PR. The asymmetry is documented rather than papered over.

## Changes

```php
final readonly class SteamId implements JsonSerializable, Stringable
{
    public function jsonSerialize(): string
    {
        return $this->value;
    }
}
```

- Narrowing the return type from the interface's `mixed` to `string` is legal covariance; PHPStan at max is clean.
- Test covers `jsonSerialize()` directly, `json_encode($id)`, and the nested case `json_encode(['steam_id' => $id])` — the last is the one that actually bites in a payload.
- Changelog entry under `[Unreleased]` and a note in `docs/guide.md` stating the shape and that decoding requires `fromSteamId64()` on the way back.

## Note on scope

Branched from `master`, independent of #26. On this branch alone `PlayerSummary` still cannot be encoded:

```
SteamId:       {"steam_id":"76561198000000000"}                        ✅
PlayerSummary: false — Non-backed enums have no default serialization  ❌
```

That failure is the enum half, fixed in #26. Both need to land before a `PlayerSummary` encodes at all. The two branches touch adjacent bullets in the `[Unreleased]` changelog section, so whichever merges second will need a trivial conflict resolution.

## Verification

- `composer test:lint` — Pint and Rector passed
- `composer test:types` — PHPStan, 0 errors
- `composer test:unit` — 113 passed, 100% coverage
- `composer test:type-coverage` — 100%
- `composer test:mutate` — 138 mutations, score 100%
