### PR TITLE
feat: add GetUserGroupList endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `GetUserGroupList` endpoint (`ISteamUser`) with the `UserGroup` DTO. Closes [#19](https://github.com/fkrzski/php-steam-api-sdk/issues/19).
 - `SteamId` now implements `JsonSerializable` and encodes to a bare string. Previously `json_encode()` emitted `{"value":"<id>"}`, since the promoted `value` property is public. Part of [#25](https://github.com/fkrzski/php-steam-api-sdk/issues/25); `DateTimeImmutable` properties on the DTOs still serialize as PHP's internal shape and remain open there.
 
 ### Fixed

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -68,6 +68,28 @@ $friends = $connector
     ->dto();
 ```
 
+## GetUserGroupListRequest
+
+```text
+new GetUserGroupListRequest(SteamId $steamId)
+```
+
+Lists the Steam groups a player belongs to. Only the group IDs come back — Steam
+exposes no group metadata on this endpoint.
+
+- Returns `list<UserGroup>`.
+- Throws `ProfileNotPublicException` when the profile is hidden.
+
+```php
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetUserGroupListRequest;
+
+$groups = $connector->send(new GetUserGroupListRequest($steamId))->dto();
+
+foreach ($groups as $group) {
+    echo $group->gid, PHP_EOL;
+}
+```
+
 ## GetOwnedGamesRequest
 
 ```text

--- a/docs/dto-reference.md
+++ b/docs/dto-reference.md
@@ -45,6 +45,14 @@ Returned by [`GetFriendListRequest`](/php-steam-api-sdk/api-reference#getfriendl
 | `relationship` | `FriendRelationship` | Relationship to the queried user. |
 | `friendSince` | `DateTimeImmutable` | When the friendship was formed. |
 
+## UserGroup
+
+Returned by [`GetUserGroupListRequest`](/php-steam-api-sdk/api-reference#getusergrouplistrequest).
+
+| Property | Type | Notes |
+| --- | --- | --- |
+| `gid` | `string` | Steam group ID. |
+
 ## OwnedGame
 
 Returned by [`GetOwnedGamesRequest`](/php-steam-api-sdk/api-reference#getownedgamesrequest).

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -59,7 +59,7 @@ Every SDK failure extends `SteamApiException`, so one catch handles them all:
 SteamApiException                (root, extends RuntimeException)
 ├── InvalidSteamIdException      Malformed SteamID64.
 ├── SteamUserNotFoundException   Vanity URL unresolved or profile missing.
-├── ProfileNotPublicException    Profile, games list, or stats are private.
+├── ProfileNotPublicException    Profile, games list, groups, or stats are private.
 ├── TooManySteamIdsException     More than 100 IDs in a batch request.
 └── SteamRateLimitException      Daily 100k quota reached; exposes the offending Limit.
 ```

--- a/src/Dto/UserGroup.php
+++ b/src/Dto/UserGroup.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Dto;
+
+final readonly class UserGroup
+{
+    public function __construct(
+        public string $gid,
+    ) {}
+
+    /**
+     * @param  array{gid: string}  $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        return new self(
+            gid: $payload['gid'],
+        );
+    }
+}

--- a/src/Http/Requests/ISteamUser/GetUserGroupListRequest.php
+++ b/src/Http/Requests/ISteamUser/GetUserGroupListRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Http\Requests\ISteamUser;
+
+use Fkrzski\SteamApiSdk\Dto\UserGroup;
+use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Override;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+final class GetUserGroupListRequest extends Request
+{
+    #[Override]
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        public readonly SteamId $steamId,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return '/ISteamUser/GetUserGroupList/v1/';
+    }
+
+    /**
+     * @return list<UserGroup>
+     */
+    public function createDtoFromResponse(Response $response): array
+    {
+        /**
+         * @var array{response?: array{
+         *     success?: bool,
+         *     error?: string,
+         *     groups?: list<array{gid: string}>,
+         * }} $body
+         */
+        $body = $response->json();
+        $responseBody = $body['response'] ?? [];
+
+        if (($responseBody['success'] ?? null) !== true) {
+            throw new ProfileNotPublicException('Steam profile is not public.');
+        }
+
+        return array_map(UserGroup::fromArray(...), $responseBody['groups'] ?? []);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function defaultQuery(): array
+    {
+        return ['steamid' => $this->steamId->value];
+    }
+}

--- a/tests/Feature/Http/Requests/ISteamUser/GetUserGroupListRequestTest.php
+++ b/tests/Feature/Http/Requests/ISteamUser/GetUserGroupListRequestTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use Fkrzski\SteamApiSdk\Dto\UserGroup;
+use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetUserGroupListRequest;
+use Fkrzski\SteamApiSdk\SteamConfig;
+use Fkrzski\SteamApiSdk\SteamConnector;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+covers([GetUserGroupListRequest::class, UserGroup::class]);
+
+function userGroupListConnector(): SteamConnector
+{
+    return new SteamConnector(new SteamConfig('test-key'));
+}
+
+function userGroupTestSteamId(): SteamId
+{
+    return SteamId::fromSteamId64('76561198000000000');
+}
+
+test('endpoint targets GetUserGroupList v1', function (): void {
+    $request = new GetUserGroupListRequest(userGroupTestSteamId());
+
+    expect($request->resolveEndpoint())->toBe('/ISteamUser/GetUserGroupList/v1/');
+});
+
+test('query includes steamid', function (): void {
+    $request = new GetUserGroupListRequest(userGroupTestSteamId());
+
+    expect($request->query()->all())->toBe([
+        'steamid' => '76561198000000000',
+    ]);
+});
+
+test('fixture response parses into UserGroup DTOs', function (): void {
+    $mock = new MockClient([
+        GetUserGroupListRequest::class => MockResponse::fixture('ISteamUser/GetUserGroupList/default'),
+    ]);
+
+    $connector = userGroupListConnector();
+    $connector->withMockClient($mock);
+
+    /** @var list<UserGroup> $dtos */
+    $dtos = $connector->send(new GetUserGroupListRequest(userGroupTestSteamId()))->dto();
+
+    expect($dtos)->toHaveCount(4)
+        ->and($dtos[0])->toBeInstanceOf(UserGroup::class)
+        ->and($dtos[0]->gid)->toBe('4218398')
+        ->and($dtos[3]->gid)->toBe('25392543');
+});
+
+test('membership-free fixture returns empty list', function (): void {
+    $mock = new MockClient([
+        GetUserGroupListRequest::class => MockResponse::fixture('ISteamUser/GetUserGroupList/empty'),
+    ]);
+
+    $connector = userGroupListConnector();
+    $connector->withMockClient($mock);
+
+    $dtos = $connector->send(new GetUserGroupListRequest(userGroupTestSteamId()))->dto();
+
+    expect($dtos)->toBeEmpty();
+});
+
+test('response without a success flag throws ProfileNotPublicException', function (): void {
+    $mock = new MockClient([
+        GetUserGroupListRequest::class => MockResponse::make(['response' => []]),
+    ]);
+
+    $connector = userGroupListConnector();
+    $connector->withMockClient($mock);
+
+    $connector->send(new GetUserGroupListRequest(userGroupTestSteamId()))->dto();
+})->throws(ProfileNotPublicException::class, 'Steam profile is not public.');
+
+test('private profile throws ProfileNotPublicException', function (): void {
+    $mock = new MockClient([
+        GetUserGroupListRequest::class => MockResponse::fixture('ISteamUser/GetUserGroupList/private'),
+    ]);
+
+    $connector = userGroupListConnector();
+    $connector->withMockClient($mock);
+
+    $connector->send(new GetUserGroupListRequest(userGroupTestSteamId()))->dto();
+})->throws(ProfileNotPublicException::class, 'Steam profile is not public.');

--- a/tests/Fixtures/Saloon/ISteamUser/GetUserGroupList/default.json
+++ b/tests/Fixtures/Saloon/ISteamUser/GetUserGroupList/default.json
@@ -1,0 +1,25 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "response": {
+            "success": true,
+            "groups": [
+                {
+                    "gid": "4218398"
+                },
+                {
+                    "gid": "25358940"
+                },
+                {
+                    "gid": "25380952"
+                },
+                {
+                    "gid": "25392543"
+                }
+            ]
+        }
+    }
+}

--- a/tests/Fixtures/Saloon/ISteamUser/GetUserGroupList/empty.json
+++ b/tests/Fixtures/Saloon/ISteamUser/GetUserGroupList/empty.json
@@ -1,0 +1,11 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "response": {
+            "success": true
+        }
+    }
+}

--- a/tests/Fixtures/Saloon/ISteamUser/GetUserGroupList/private.json
+++ b/tests/Fixtures/Saloon/ISteamUser/GetUserGroupList/private.json
@@ -1,0 +1,12 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "response": {
+            "success": false,
+            "error": "Private profile"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds the `ISteamUser/GetUserGroupList/v1/` endpoint as `GetUserGroupListRequest`, returning `list<UserGroup>` — a readonly DTO carrying the group `gid`. Steam exposes no group metadata on this endpoint, so `gid` is all there is.

A private profile answers with HTTP 200 and `{"response":{"success":false,"error":"Private profile"}}`, so the request raises `ProfileNotPublicException` with the same message the other profile-scoped requests use. A body missing `success` altogether is treated the same way.

Fixtures cover the public (4 groups), group-free, and private responses; docs and the changelog are updated alongside.

## Why

Closes #19.