### PR TITLE
feat: add GetPlayerBans endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BC break.** `TooManySteamIdsException::forCount()` now takes a required `string $endpoint`, so the message names the request that hit the cap.
 - **BC break.** `CommentPermission` and `CommunityVisibility` are now backed enums. `CommunityVisibility` is backed by `int` using Steam's own `communityvisibilitystate` codes (`Hidden = 1`, `Visible = 3`); `CommentPermission` is backed by `string` (`'everyone'`, `'nobody'`, `'friends_only'`), because Steam omits the `commentpermission` key entirely for the friends-only case and so has no wire integer for it. Case names are unchanged and `fromApiValue()` keeps its signature and its `UnexpectedValueException` on unknown input — only code that relies on these being pure enums (a `UnitEnum` type hint, or `instanceof UnitEnum` checks) needs updating.
 
 ### Added
 
+- `GetPlayerBans` endpoint (`ISteamUser`) with the `PlayerBan` DTO and `EconomyBan` enum. Steam's `EconomyBan` value set is open, so unrecognised values fall back to `Unknown` instead of throwing. Closes [#18](https://github.com/fkrzski/php-steam-api-sdk/issues/18).
 - `GetUserGroupList` endpoint (`ISteamUser`) with the `UserGroup` DTO. Closes [#19](https://github.com/fkrzski/php-steam-api-sdk/issues/19).
 - `SteamId` now implements `JsonSerializable` and encodes to a bare string. Previously `json_encode()` emitted `{"value":"<id>"}`, since the promoted `value` property is public. Part of [#25](https://github.com/fkrzski/php-steam-api-sdk/issues/25); `DateTimeImmutable` properties on the DTOs still serialize as PHP's internal shape and remain open there.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -90,6 +90,30 @@ foreach ($groups as $group) {
 }
 ```
 
+## GetPlayerBansRequest
+
+```text
+new GetPlayerBansRequest(list<SteamId> $steamIds)
+```
+
+Fetches VAC, game, community and economy ban status for a batch of players. Accepts
+**1 to 100** IDs. Unlike the other batch endpoints this one needs no public profile —
+ban status comes back for private profiles too.
+
+- Returns `list<PlayerBan>`.
+- Throws `InvalidArgumentException` on an empty list.
+- Throws `TooManySteamIdsException` when more than 100 IDs are passed.
+
+```php
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetPlayerBansRequest;
+
+$bans = $connector->send(new GetPlayerBansRequest([$steamId]))->dto();
+
+foreach ($bans as $ban) {
+    echo $ban->steamId, ' — VAC bans: ', $ban->numberOfVacBans, PHP_EOL;
+}
+```
+
 ## GetOwnedGamesRequest
 
 ```text

--- a/docs/dto-reference.md
+++ b/docs/dto-reference.md
@@ -53,6 +53,20 @@ Returned by [`GetUserGroupListRequest`](/php-steam-api-sdk/api-reference#getuser
 | --- | --- | --- |
 | `gid` | `string` | Steam group ID. |
 
+## PlayerBan
+
+Returned by [`GetPlayerBansRequest`](/php-steam-api-sdk/api-reference#getplayerbansrequest).
+
+| Property | Type | Notes |
+| --- | --- | --- |
+| `steamId` | `SteamId` | The player's 64-bit ID. |
+| `isCommunityBanned` | `bool` | Banned from Steam Community. |
+| `isVacBanned` | `bool` | Has an active VAC ban. |
+| `numberOfVacBans` | `int` | Total VAC bans on record. |
+| `numberOfGameBans` | `int` | Total developer-issued game bans. |
+| `daysSinceLastBan` | `int` | Days since the most recent ban. Steam reports `0` for players with no VAC or game bans, so read it together with the two counters. |
+| `economyBan` | `EconomyBan` | Trade/market ban status. |
+
 ## OwnedGame
 
 Returned by [`GetOwnedGamesRequest`](/php-steam-api-sdk/api-reference#getownedgamesrequest).
@@ -124,3 +138,10 @@ are the SDK's own vocabulary rather than the wire values. Use `fromApiValue()` t
 from the raw API payload.
 
 `FriendRelationship` (backed by `string`) — `All` (`'all'`), `Friend` (`'friend'`).
+
+`EconomyBan` (backed by `string`) — `None` (`'none'`), `Probation` (`'probation'`),
+`Banned` (`'banned'`), `Unknown` (`'unknown'`). Steam sends this field as a string and
+documents only `none` and `probation` before trailing off with "and so forth" —
+`banned` is observed on live accounts but undocumented, so the value set is provably
+open. `fromApiValue()` therefore maps anything unrecognised to `Unknown` rather than
+throwing, so a new ban state shipped by Valve cannot break callers.

--- a/src/Dto/PlayerBan.php
+++ b/src/Dto/PlayerBan.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Dto;
+
+use Fkrzski\SteamApiSdk\Enums\EconomyBan;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+
+final readonly class PlayerBan
+{
+    public function __construct(
+        public SteamId $steamId,
+        public bool $isCommunityBanned,
+        public bool $isVacBanned,
+        public int $numberOfVacBans,
+        public int $numberOfGameBans,
+        public int $daysSinceLastBan,
+        public EconomyBan $economyBan,
+    ) {}
+
+    /**
+     * @param  array{
+     *     SteamId: string,
+     *     CommunityBanned: bool,
+     *     VACBanned: bool,
+     *     NumberOfVACBans: int,
+     *     DaysSinceLastBan: int,
+     *     NumberOfGameBans: int,
+     *     EconomyBan: string,
+     * }  $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        return new self(
+            steamId: SteamId::fromSteamId64($payload['SteamId']),
+            isCommunityBanned: $payload['CommunityBanned'],
+            isVacBanned: $payload['VACBanned'],
+            numberOfVacBans: $payload['NumberOfVACBans'],
+            numberOfGameBans: $payload['NumberOfGameBans'],
+            daysSinceLastBan: $payload['DaysSinceLastBan'],
+            economyBan: EconomyBan::fromApiValue($payload['EconomyBan']),
+        );
+    }
+}

--- a/src/Enums/EconomyBan.php
+++ b/src/Enums/EconomyBan.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Enums;
+
+enum EconomyBan: string
+{
+    case None = 'none';
+    case Probation = 'probation';
+    case Banned = 'banned';
+    case Unknown = 'unknown';
+
+    /**
+     * Steam documents only "none" and "probation", then trails off with "and so
+     * forth" — "banned" is observed on live accounts but undocumented
+     */
+    public static function fromApiValue(string $value): self
+    {
+        return self::tryFrom($value) ?? self::Unknown;
+    }
+}

--- a/src/Exceptions/TooManySteamIdsException.php
+++ b/src/Exceptions/TooManySteamIdsException.php
@@ -6,8 +6,8 @@ namespace Fkrzski\SteamApiSdk\Exceptions;
 
 final class TooManySteamIdsException extends SteamApiException
 {
-    public static function forCount(int $count): self
+    public static function forCount(int $count, string $endpoint): self
     {
-        return new self(sprintf('GetPlayerSummaries accepts up to 100 SteamIDs, %d given.', $count));
+        return new self(sprintf('%s accepts up to 100 SteamIDs, %d given.', $endpoint, $count));
     }
 }

--- a/src/Http/Requests/ISteamUser/GetPlayerBansRequest.php
+++ b/src/Http/Requests/ISteamUser/GetPlayerBansRequest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Http\Requests\ISteamUser;
+
+use Fkrzski\SteamApiSdk\Dto\PlayerBan;
+use Fkrzski\SteamApiSdk\Exceptions\TooManySteamIdsException;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use InvalidArgumentException;
+use Override;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+final class GetPlayerBansRequest extends Request
+{
+    public const int MAX_STEAM_IDS = 100;
+
+    #[Override]
+    protected Method $method = Method::GET;
+
+    /**
+     * @param  list<SteamId>  $steamIds
+     */
+    public function __construct(
+        public readonly array $steamIds,
+    ) {
+        $count = count($steamIds);
+
+        if ($count === 0) {
+            throw new InvalidArgumentException('GetPlayerBansRequest requires at least one SteamId.');
+        }
+
+        if ($count > self::MAX_STEAM_IDS) {
+            throw TooManySteamIdsException::forCount($count, 'GetPlayerBans');
+        }
+    }
+
+    public function resolveEndpoint(): string
+    {
+        return '/ISteamUser/GetPlayerBans/v1/';
+    }
+
+    /**
+     * @return list<PlayerBan>
+     */
+    public function createDtoFromResponse(Response $response): array
+    {
+        /**
+         * Unlike the other ISteamUser endpoints, GetPlayerBans returns the player
+         * list at the top level rather than nested under a "response" key.
+         *
+         * @var array{players?: list<array{
+         *     SteamId: string,
+         *     CommunityBanned: bool,
+         *     VACBanned: bool,
+         *     NumberOfVACBans: int,
+         *     DaysSinceLastBan: int,
+         *     NumberOfGameBans: int,
+         *     EconomyBan: string,
+         * }>} $body
+         */
+        $body = $response->json();
+        $players = $body['players'] ?? [];
+
+        return array_map(PlayerBan::fromArray(...), $players);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function defaultQuery(): array
+    {
+        return [
+            'steamids' => implode(',', $this->steamIds),
+        ];
+    }
+}

--- a/src/Http/Requests/ISteamUser/GetPlayerSummariesRequest.php
+++ b/src/Http/Requests/ISteamUser/GetPlayerSummariesRequest.php
@@ -33,7 +33,7 @@ final class GetPlayerSummariesRequest extends Request
         }
 
         if ($count > self::MAX_STEAM_IDS) {
-            throw TooManySteamIdsException::forCount($count);
+            throw TooManySteamIdsException::forCount($count, 'GetPlayerSummaries');
         }
     }
 

--- a/tests/Feature/Http/Requests/ISteamUser/GetPlayerBansRequestTest.php
+++ b/tests/Feature/Http/Requests/ISteamUser/GetPlayerBansRequestTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+use Fkrzski\SteamApiSdk\Dto\PlayerBan;
+use Fkrzski\SteamApiSdk\Enums\EconomyBan;
+use Fkrzski\SteamApiSdk\Exceptions\TooManySteamIdsException;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetPlayerBansRequest;
+use Fkrzski\SteamApiSdk\SteamConfig;
+use Fkrzski\SteamApiSdk\SteamConnector;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+covers([GetPlayerBansRequest::class, PlayerBan::class]);
+
+function bansConnector(): SteamConnector
+{
+    return new SteamConnector(new SteamConfig('test-key'));
+}
+
+/**
+ * @return list<PlayerBan>
+ */
+function sendBansFixture(string $fixture, int $steamIdCount = 1): array
+{
+    $mock = new MockClient([
+        GetPlayerBansRequest::class => MockResponse::fixture('ISteamUser/GetPlayerBans/'.$fixture),
+    ]);
+
+    $connector = bansConnector();
+    $connector->withMockClient($mock);
+
+    /** @var list<PlayerBan> $dtos */
+    $dtos = $connector->send(new GetPlayerBansRequest(makeSteamIds($steamIdCount)))->dto();
+
+    return $dtos;
+}
+
+test('endpoint targets GetPlayerBans v1', function (): void {
+    $request = new GetPlayerBansRequest(makeSteamIds(1));
+
+    expect($request->resolveEndpoint())->toBe('/ISteamUser/GetPlayerBans/v1/');
+});
+
+test('query joins steamids with comma', function (): void {
+    $request = new GetPlayerBansRequest(makeSteamIds(2));
+
+    expect($request->query()->all())->toBe([
+        'steamids' => '76561198000000000,76561198000000001',
+    ]);
+});
+
+test('empty steamid list rejected', function (): void {
+    new GetPlayerBansRequest([]);
+})->throws(InvalidArgumentException::class, 'GetPlayerBansRequest requires at least one SteamId.');
+
+test('more than 100 steamids rejected', function (): void {
+    new GetPlayerBansRequest(makeSteamIds(101));
+})->throws(TooManySteamIdsException::class, 'GetPlayerBans accepts up to 100 SteamIDs, 101 given.');
+
+test('exactly 100 steamids accepted', function (): void {
+    $request = new GetPlayerBansRequest(makeSteamIds(100));
+
+    expect($request->steamIds)->toHaveCount(100);
+});
+
+test('fixture response parses top-level players into PlayerBan DTOs', function (): void {
+    $dtos = sendBansFixture('default', 2);
+
+    expect($dtos)->toHaveCount(2)
+        ->and($dtos[0])->toBeInstanceOf(PlayerBan::class)
+        ->and($dtos[0]->steamId)->toBeInstanceOf(SteamId::class)
+        ->and($dtos[0]->steamId->value)->toBe('76561198000000000')
+        ->and($dtos[0]->isCommunityBanned)->toBeFalse()
+        ->and($dtos[0]->isVacBanned)->toBeFalse()
+        ->and($dtos[0]->numberOfVacBans)->toBe(0)
+        ->and($dtos[0]->numberOfGameBans)->toBe(0)
+        ->and($dtos[0]->daysSinceLastBan)->toBe(0)
+        ->and($dtos[0]->economyBan)->toBe(EconomyBan::None)
+        ->and($dtos[1]->steamId->value)->toBe('76561198000000001')
+        ->and($dtos[1]->isCommunityBanned)->toBeFalse()
+        ->and($dtos[1]->isVacBanned)->toBeTrue()
+        ->and($dtos[1]->numberOfVacBans)->toBe(1)
+        ->and($dtos[1]->numberOfGameBans)->toBe(0)
+        ->and($dtos[1]->daysSinceLastBan)->toBe(3216)
+        ->and($dtos[1]->economyBan)->toBe(EconomyBan::None);
+});
+
+test('community banned player parses every ban counter', function (): void {
+    $dtos = sendBansFixture('community_banned');
+
+    expect($dtos)->toHaveCount(1)
+        ->and($dtos[0]->steamId->value)->toBe('76561198000000002')
+        ->and($dtos[0]->isCommunityBanned)->toBeTrue()
+        ->and($dtos[0]->isVacBanned)->toBeTrue()
+        ->and($dtos[0]->numberOfVacBans)->toBe(63)
+        ->and($dtos[0]->numberOfGameBans)->toBe(85)
+        ->and($dtos[0]->daysSinceLastBan)->toBe(209)
+        ->and($dtos[0]->economyBan)->toBe(EconomyBan::None);
+});
+
+test('economy banned player maps EconomyBan to the Banned case', function (): void {
+    $dtos = sendBansFixture('economy_banned');
+
+    expect($dtos)->toHaveCount(1)
+        ->and($dtos[0]->steamId->value)->toBe('76561198000000003')
+        ->and($dtos[0]->isCommunityBanned)->toBeTrue()
+        ->and($dtos[0]->isVacBanned)->toBeFalse()
+        ->and($dtos[0]->economyBan)->toBe(EconomyBan::Banned);
+});
+
+test('empty players list yields no DTOs', function (): void {
+    expect(sendBansFixture('empty'))->toBe([]);
+});
+
+test('response without a players key yields no DTOs', function (): void {
+    $mock = new MockClient([
+        GetPlayerBansRequest::class => MockResponse::make(['unexpected' => true]),
+    ]);
+
+    $connector = bansConnector();
+    $connector->withMockClient($mock);
+
+    expect($connector->send(new GetPlayerBansRequest(makeSteamIds(1)))->dto())->toBe([]);
+});

--- a/tests/Feature/Http/Requests/ISteamUser/GetPlayerSummariesRequestTest.php
+++ b/tests/Feature/Http/Requests/ISteamUser/GetPlayerSummariesRequestTest.php
@@ -21,19 +21,6 @@ function summariesConnector(): SteamConnector
     return new SteamConnector(new SteamConfig('test-key'));
 }
 
-/**
- * @return list<SteamId>
- */
-function makeSteamIds(int $count): array
-{
-    $base = 76561198000000000;
-
-    return array_map(
-        static fn (int $offset): SteamId => SteamId::fromSteamId64((string) ($base + $offset)),
-        range(0, $count - 1),
-    );
-}
-
 test('PlayerSummary defaults profilestate and personastate when keys absent', function (): void {
     $summary = PlayerSummary::fromArray([
         'steamid' => '76561198000000000',

--- a/tests/Fixtures/Saloon/ISteamUser/GetPlayerBans/community_banned.json
+++ b/tests/Fixtures/Saloon/ISteamUser/GetPlayerBans/community_banned.json
@@ -1,0 +1,19 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "players": [
+            {
+                "SteamId": "76561198000000002",
+                "CommunityBanned": true,
+                "VACBanned": true,
+                "NumberOfVACBans": 63,
+                "DaysSinceLastBan": 209,
+                "NumberOfGameBans": 85,
+                "EconomyBan": "none"
+            }
+        ]
+    }
+}

--- a/tests/Fixtures/Saloon/ISteamUser/GetPlayerBans/default.json
+++ b/tests/Fixtures/Saloon/ISteamUser/GetPlayerBans/default.json
@@ -1,0 +1,28 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "players": [
+            {
+                "SteamId": "76561198000000000",
+                "CommunityBanned": false,
+                "VACBanned": false,
+                "NumberOfVACBans": 0,
+                "DaysSinceLastBan": 0,
+                "NumberOfGameBans": 0,
+                "EconomyBan": "none"
+            },
+            {
+                "SteamId": "76561198000000001",
+                "CommunityBanned": false,
+                "VACBanned": true,
+                "NumberOfVACBans": 1,
+                "DaysSinceLastBan": 3216,
+                "NumberOfGameBans": 0,
+                "EconomyBan": "none"
+            }
+        ]
+    }
+}

--- a/tests/Fixtures/Saloon/ISteamUser/GetPlayerBans/economy_banned.json
+++ b/tests/Fixtures/Saloon/ISteamUser/GetPlayerBans/economy_banned.json
@@ -1,0 +1,19 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "players": [
+            {
+                "SteamId": "76561198000000003",
+                "CommunityBanned": true,
+                "VACBanned": false,
+                "NumberOfVACBans": 0,
+                "DaysSinceLastBan": 0,
+                "NumberOfGameBans": 0,
+                "EconomyBan": "banned"
+            }
+        ]
+    }
+}

--- a/tests/Fixtures/Saloon/ISteamUser/GetPlayerBans/empty.json
+++ b/tests/Fixtures/Saloon/ISteamUser/GetPlayerBans/empty.json
@@ -1,0 +1,9 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "players": []
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,6 +2,20 @@
 
 declare(strict_types=1);
 
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 use Saloon\MockConfig;
 
 MockConfig::throwOnMissingFixtures();
+
+/**
+ * @return list<SteamId>
+ */
+function makeSteamIds(int $count): array
+{
+    $base = 76561198000000000;
+
+    return array_map(
+        static fn (int $offset): SteamId => SteamId::fromSteamId64((string) ($base + $offset)),
+        range(0, $count - 1),
+    );
+}

--- a/tests/Unit/Enums/EconomyBanTest.php
+++ b/tests/Unit/Enums/EconomyBanTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Fkrzski\SteamApiSdk\Enums\EconomyBan;
+
+covers(EconomyBan::class);
+
+test('maps API string values to enum cases', function (string $value, EconomyBan $expected): void {
+    expect(EconomyBan::fromApiValue($value))->toBe($expected);
+})->with([
+    'none' => ['none', EconomyBan::None],
+    'probation' => ['probation', EconomyBan::Probation],
+    'banned' => ['banned', EconomyBan::Banned],
+]);
+
+test('unknown values degrade to Unknown instead of throwing', function (string $value): void {
+    expect(EconomyBan::fromApiValue($value))->toBe(EconomyBan::Unknown);
+})->with([
+    'undocumented future state' => ['permanent'],
+    'empty string' => [''],
+    'wrong casing' => ['None'],
+]);
+
+test('backing values mirror the wire vocabulary and survive json_encode', function (): void {
+    expect(EconomyBan::None->value)->toBe('none')
+        ->and(EconomyBan::Probation->value)->toBe('probation')
+        ->and(EconomyBan::Banned->value)->toBe('banned')
+        ->and(EconomyBan::Unknown->value)->toBe('unknown')
+        ->and(json_encode(EconomyBan::Banned, JSON_THROW_ON_ERROR))->toBe('"banned"');
+});


### PR DESCRIPTION
Closes #18.

Adds the `GetPlayerBans` endpoint (`ISteamUser`) with the `PlayerBan` DTO and the `EconomyBan` enum.

## Notes on the implementation

**The response shape differs from the rest of `ISteamUser`.** `GetPlayerBans` returns the player list at the top level (`{"players": [...]}`) rather than nested under a `response` key, and uses PascalCase field names (`SteamId`, `VACBanned`, `NumberOfVACBans`). `createDtoFromResponse()` reads accordingly.

**`EconomyBan` falls back to `Unknown` rather than throwing.** Valve documents only `none` and `probation`, then trails off with "and so forth" — but live accounts return `banned`, which appears in no documentation. The value set is provably open, so a strict mapping would break callers the next time Valve adds a state. This deliberately departs from `CommunityVisibility::fromApiValue()`, whose value set *is* closed; the raw `UnexpectedValueException` it throws would also escape the `SteamApiException` hierarchy that `docs/guide.md` promises covers every SDK failure.

**`daysSinceLastBan` is passed through unchanged.** Steam reports `0` both for "banned today" and for players with no bans at all. Deriving `null` from the ban counters was considered and rejected — this is an SDK, not a wrapper. The ambiguity is documented in the DTO reference.

**`TooManySteamIdsException::forCount()` gained a required `$endpoint` argument** so the message names the request that hit the cap instead of always saying `GetPlayerSummaries`. BC break on a public static factory, noted in the changelog. The message for `GetPlayerSummaries` itself is unchanged.

**`makeSteamIds()` moved to `tests/Pest.php`.** Pest loads every test file into one process, so redeclaring the helper in the new test would have been a fatal error.

Fixtures reuse the ban shapes observed on live accounts (VAC-only, community, economy, clean) but with synthetic SteamIDs, to keep real banned accounts out of the repo.

## Checks

`composer test` passes end to end: pint, rector, phpstan, profanity, 138 tests / 295 assertions, 100% coverage, 100% type coverage, and 160/160 mutants killed (MSI 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)