### PR TITLE
fix: map HTTP failures to the SDK exception hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **BC break.** `SteamApiException` declares its own constructor, `__construct(string $message, ?Response $response = null)`. `getCode()` is now the HTTP status, or `0` when the failure was raised before a request went out.
+- HTTP failures now raise SDK exceptions instead of Saloon's `RequestException` subclasses, so catching `SteamApiException` really does cover every failure. Closes [#20](https://github.com/fkrzski/php-steam-api-sdk/issues/20).
+- `GetPlayerAchievements`, `GetUserStatsForGame` and `GetUserGroupList` no longer detect a private profile from the response body. Steam answers with an error status in all three cases (400, 400 and 403), so none of those checks ever ran and the request failed with a Saloon exception instead.
 - **BC break.** `TooManySteamIdsException::forCount()` now takes a required `string $endpoint`, so the message names the request that hit the cap.
 - **BC break.** `CommentPermission` and `CommunityVisibility` are now backed enums. `CommunityVisibility` is backed by `int` using Steam's own `communityvisibilitystate` codes (`Hidden = 1`, `Visible = 3`); `CommentPermission` is backed by `string` (`'everyone'`, `'nobody'`, `'friends_only'`), because Steam omits the `commentpermission` key entirely for the friends-only case and so has no wire integer for it. Case names are unchanged and `fromApiValue()` keeps its signature and its `UnexpectedValueException` on unknown input — only code that relies on these being pure enums (a `UnitEnum` type hint, or `instanceof UnitEnum` checks) needs updating.
 
 ### Added
 
+- `InvalidApiKeyException` for a missing (HTTP 400) or rejected (HTTP 403) API key. Steam reports both as HTML, which is what tells them apart from a private profile on the same status.
+- `StatsUnavailableException`, thrown by `GetPlayerAchievements` when Steam withholds achievements. It deliberately names both possible causes: Steam returns an identical `Requested app has no stats` body for an app without achievements and for a private profile.
+- `SteamApiException::$response` exposes the response behind an HTTP failure.
 - `GetPlayerBans` endpoint (`ISteamUser`) with the `PlayerBan` DTO and `EconomyBan` enum. Steam's `EconomyBan` value set is open, so unrecognised values fall back to `Unknown` instead of throwing. Closes [#18](https://github.com/fkrzski/php-steam-api-sdk/issues/18).
 - `GetUserGroupList` endpoint (`ISteamUser`) with the `UserGroup` DTO. Closes [#19](https://github.com/fkrzski/php-steam-api-sdk/issues/19).
 - `SteamId` now implements `JsonSerializable` and encodes to a bare string. Previously `json_encode()` emitted `{"value":"<id>"}`, since the promoted `value` property is public. Part of [#25](https://github.com/fkrzski/php-steam-api-sdk/issues/25); `DateTimeImmutable` properties on the DTOs still serialize as PHP's internal shape and remain open there.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -176,7 +176,7 @@ Returns a player's achievements for one game, each with its unlock state and tim
 `language` localises the achievement name and description.
 
 - Returns `PlayerAchievements`.
-- Throws `ProfileNotPublicException` when the profile is hidden.
+- Throws `StatsUnavailableException` when `appId` exposes no achievements **or** the profile is hidden — Steam reports both identically.
 
 ```php
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetPlayerAchievementsRequest;

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -46,10 +46,10 @@ $summaries = $connector
     ->dto();
 ```
 
-The connector uses Saloon's `AlwaysThrowOnErrors`, so a non-2xx response raises a
-Saloon exception before you ever reach `->dto()`. Domain-level problems (a private
-profile, an unknown vanity URL) surface as SDK exceptions instead — see below. Which
-request returns which DTO is listed in the [API reference](/php-steam-api-sdk/api-reference).
+The connector uses Saloon's `AlwaysThrowOnErrors`, so a non-2xx response fails before
+you ever reach `->dto()`. Those failures are translated into the SDK's own exceptions,
+so no Saloon class ever escapes — see below. Which request returns which DTO is listed
+in the [API reference](/php-steam-api-sdk/api-reference).
 
 ## Exceptions
 
@@ -60,6 +60,8 @@ SteamApiException                (root, extends RuntimeException)
 ├── InvalidSteamIdException      Malformed SteamID64.
 ├── SteamUserNotFoundException   Vanity URL unresolved or profile missing.
 ├── ProfileNotPublicException    Profile, games list, groups, or stats are private.
+├── InvalidApiKeyException       API key missing, wrong, or revoked.
+├── StatsUnavailableException    Stats withheld: no such stats, or private profile.
 ├── TooManySteamIdsException     More than 100 IDs in a batch request.
 └── SteamRateLimitException      Daily 100k quota reached; exposes the offending Limit.
 ```
@@ -67,3 +69,44 @@ SteamApiException                (root, extends RuntimeException)
 Catch the leaf you care about, or the root `SteamApiException` to handle every
 SDK failure uniformly. The [API reference](/php-steam-api-sdk/api-reference) notes which request throws
 which exception.
+
+### Inspecting the failed response
+
+Exceptions raised from an HTTP failure carry the response that produced them, and
+their code is the HTTP status:
+
+```php
+use Fkrzski\SteamApiSdk\Exceptions\SteamApiException;
+
+try {
+    $summaries = $connector->send(new GetPlayerSummariesRequest([$id]))->dto();
+} catch (SteamApiException $e) {
+    $e->getCode();          // 403
+    $e->response?->body();  // raw Steam payload, or null for client-side failures
+}
+```
+
+`response` is `null` for failures raised before a request went out — a malformed
+SteamID64, an oversized batch, or the daily quota being exhausted locally.
+
+### How statuses are mapped
+
+Steam signals failure in two different ways, and the SDK reads both:
+
+| Steam's answer | Exception |
+| --- | --- |
+| `400` + HTML naming the `key` parameter | `InvalidApiKeyException` (missing) |
+| `403` + HTML naming the `key` parameter | `InvalidApiKeyException` (rejected) |
+| `400` + JSON, on `ISteamUserStats` | `StatsUnavailableException` / `ProfileNotPublicException` |
+| `401` or `403` | `ProfileNotPublicException` |
+| `429` | `SteamRateLimitException` |
+| any other `4xx` / `5xx` | `SteamApiException` |
+| `200` with an empty or `success: 42` payload | `ProfileNotPublicException` / `SteamUserNotFoundException` |
+
+Steam overloads `400` across unrelated causes. Key errors are the one case it answers
+with HTML rather than JSON, which is what keeps a misconfigured key from being reported
+as a data problem. `GetPlayerAchievements` goes further and returns a byte-identical
+`Requested app has no stats` body whether the app has no achievements or the profile is
+private, so `StatsUnavailableException` names both causes rather than guessing between
+them. `GetUserStatsForGame` answers an empty object for a private profile, which is
+unambiguous and maps to `ProfileNotPublicException`.

--- a/src/Exceptions/InvalidApiKeyException.php
+++ b/src/Exceptions/InvalidApiKeyException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Exceptions;
+
+use Saloon\Http\Response;
+
+final class InvalidApiKeyException extends SteamApiException
+{
+    public static function missing(Response $response): self
+    {
+        return new self('Steam API key is missing. Check the key passed to SteamConfig.', $response);
+    }
+
+    public static function rejected(Response $response): self
+    {
+        return new self('Steam rejected the API key. Check that it is valid and active.', $response);
+    }
+}

--- a/src/Exceptions/ProfileNotPublicException.php
+++ b/src/Exceptions/ProfileNotPublicException.php
@@ -4,4 +4,21 @@ declare(strict_types=1);
 
 namespace Fkrzski\SteamApiSdk\Exceptions;
 
-final class ProfileNotPublicException extends SteamApiException {}
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Saloon\Http\Response;
+
+final class ProfileNotPublicException extends SteamApiException
+{
+    public static function forSteamId(SteamId $steamId, ?Response $response = null): self
+    {
+        return new self(sprintf('Steam profile %s is not public.', $steamId), $response);
+    }
+
+    /**
+     * Used where the profile is not known, such as status mapping on the connector.
+     */
+    public static function fromResponse(Response $response): self
+    {
+        return new self('Steam profile is not public.', $response);
+    }
+}

--- a/src/Exceptions/StatsUnavailableException.php
+++ b/src/Exceptions/StatsUnavailableException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Exceptions;
+
+use Saloon\Http\Response;
+
+final class StatsUnavailableException extends SteamApiException
+{
+    public static function forAppId(int $appId, Response $response): self
+    {
+        return new self(
+            sprintf('Steam returned no stats for app %d: it exposes none, or the profile is private.', $appId),
+            $response,
+        );
+    }
+}

--- a/src/Exceptions/SteamApiException.php
+++ b/src/Exceptions/SteamApiException.php
@@ -5,5 +5,14 @@ declare(strict_types=1);
 namespace Fkrzski\SteamApiSdk\Exceptions;
 
 use RuntimeException;
+use Saloon\Http\Response;
 
-class SteamApiException extends RuntimeException {}
+class SteamApiException extends RuntimeException
+{
+    public function __construct(
+        string $message,
+        public readonly ?Response $response = null,
+    ) {
+        parent::__construct($message, $response?->status() ?? 0);
+    }
+}

--- a/src/Http/Requests/IPlayerService/GetOwnedGamesRequest.php
+++ b/src/Http/Requests/IPlayerService/GetOwnedGamesRequest.php
@@ -51,7 +51,7 @@ final class GetOwnedGamesRequest extends Request
         $responseBody = $body['response'] ?? [];
 
         if (! array_key_exists('game_count', $responseBody)) {
-            throw new ProfileNotPublicException('Steam profile is not public.');
+            throw ProfileNotPublicException::forSteamId($this->steamId);
         }
 
         return array_map(OwnedGame::fromArray(...), $responseBody['games'] ?? []);

--- a/src/Http/Requests/ISteamUser/GetUserGroupListRequest.php
+++ b/src/Http/Requests/ISteamUser/GetUserGroupListRequest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Fkrzski\SteamApiSdk\Http\Requests\ISteamUser;
 
 use Fkrzski\SteamApiSdk\Dto\UserGroup;
-use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 use Override;
 use Saloon\Enums\Method;
@@ -31,21 +30,10 @@ final class GetUserGroupListRequest extends Request
      */
     public function createDtoFromResponse(Response $response): array
     {
-        /**
-         * @var array{response?: array{
-         *     success?: bool,
-         *     error?: string,
-         *     groups?: list<array{gid: string}>,
-         * }} $body
-         */
+        /** @var array{response?: array{groups?: list<array{gid: string}>}} $body */
         $body = $response->json();
-        $responseBody = $body['response'] ?? [];
 
-        if (($responseBody['success'] ?? null) !== true) {
-            throw new ProfileNotPublicException('Steam profile is not public.');
-        }
-
-        return array_map(UserGroup::fromArray(...), $responseBody['groups'] ?? []);
+        return array_map(UserGroup::fromArray(...), $body['response']['groups'] ?? []);
     }
 
     /**

--- a/src/Http/Requests/ISteamUserStats/GetPlayerAchievementsRequest.php
+++ b/src/Http/Requests/ISteamUserStats/GetPlayerAchievementsRequest.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats;
 
 use Fkrzski\SteamApiSdk\Dto\PlayerAchievements;
-use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
+use Fkrzski\SteamApiSdk\Exceptions\StatsUnavailableException;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 use Override;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 use Saloon\Http\Response;
+use Throwable;
 
 final class GetPlayerAchievementsRequest extends Request
 {
@@ -28,10 +29,25 @@ final class GetPlayerAchievementsRequest extends Request
         return '/ISteamUserStats/GetPlayerAchievements/v1/';
     }
 
+    /**
+     * Steam answers 400 identically for an app without stats and for a private
+     * profile, so the cause cannot be recovered. A missing API key also lands on
+     * 400 but as HTML, which the connector claims.
+     */
+    #[Override]
+    public function getRequestException(Response $response, ?Throwable $senderException): ?Throwable
+    {
+        if ($response->status() !== 400 || ! json_validate($response->body())) {
+            return null;
+        }
+
+        return StatsUnavailableException::forAppId($this->appId, $response);
+    }
+
     public function createDtoFromResponse(Response $response): PlayerAchievements
     {
         /**
-         * @var array{playerstats?: array{
+         * @var array{playerstats: array{
          *     steamID: string,
          *     gameName: string,
          *     achievements: list<array{apiname: string, achieved: int, unlocktime: int, name?: string, description?: string}>,
@@ -39,10 +55,6 @@ final class GetPlayerAchievementsRequest extends Request
          * }} $body
          */
         $body = $response->json();
-
-        if (! isset($body['playerstats']['success']) || $body['playerstats']['success'] === false) {
-            throw new ProfileNotPublicException('Steam profile is not public.');
-        }
 
         return PlayerAchievements::fromArray($body['playerstats']);
     }

--- a/src/Http/Requests/ISteamUserStats/GetUserStatsForGameRequest.php
+++ b/src/Http/Requests/ISteamUserStats/GetUserStatsForGameRequest.php
@@ -11,6 +11,7 @@ use Override;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 use Saloon\Http\Response;
+use Throwable;
 
 final class GetUserStatsForGameRequest extends Request
 {
@@ -28,10 +29,24 @@ final class GetUserStatsForGameRequest extends Request
         return '/ISteamUserStats/GetUserStatsForGame/v2/';
     }
 
+    /**
+     * A private profile answers 400 with an empty JSON object; a missing API key
+     * answers 400 with HTML, which belongs to the connector.
+     */
+    #[Override]
+    public function getRequestException(Response $response, ?Throwable $senderException): ?Throwable
+    {
+        if ($response->status() !== 400 || ! json_validate($response->body())) {
+            return null;
+        }
+
+        return ProfileNotPublicException::forSteamId($this->steamId, $response);
+    }
+
     public function createDtoFromResponse(Response $response): UserStats
     {
         /**
-         * @var array{playerstats?: array{
+         * @var array{playerstats: array{
          *     steamID: string,
          *     gameName: string,
          *     stats?: list<array{name: string, value: int|float}>,
@@ -39,10 +54,6 @@ final class GetUserStatsForGameRequest extends Request
          * }} $body
          */
         $body = $response->json();
-
-        if (! array_key_exists('playerstats', $body)) {
-            throw new ProfileNotPublicException('Steam profile is not public.');
-        }
 
         return UserStats::fromArray($body['playerstats']);
     }

--- a/src/SteamConnector.php
+++ b/src/SteamConnector.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace Fkrzski\SteamApiSdk;
 
+use Fkrzski\SteamApiSdk\Exceptions\InvalidApiKeyException;
+use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
+use Fkrzski\SteamApiSdk\Exceptions\SteamApiException;
 use Fkrzski\SteamApiSdk\Exceptions\SteamRateLimitException;
+use Override;
 use Saloon\Http\Connector;
+use Saloon\Http\Response;
 use Saloon\RateLimitPlugin\Contracts\RateLimitStore;
 use Saloon\RateLimitPlugin\Limit;
 use Saloon\RateLimitPlugin\Stores\MemoryStore;
 use Saloon\RateLimitPlugin\Traits\HasRateLimits;
 use Saloon\Traits\Plugins\AlwaysThrowOnErrors;
+use Throwable;
 
 class SteamConnector extends Connector
 {
@@ -24,6 +30,34 @@ class SteamConnector extends Connector
     public function resolveBaseUrl(): string
     {
         return 'https://api.steampowered.com';
+    }
+
+    /**
+     * 429 is absent on purpose: the rate limit plugin runs as PipeOrder::FIRST
+     * and throws before AlwaysThrowOnErrors (PipeOrder::LAST) reaches this.
+     */
+    #[Override]
+    public function getRequestException(Response $response, ?Throwable $senderException): ?Throwable
+    {
+        $status = $response->status();
+        $body = $response->body();
+
+        // Key errors arrive as HTML, every real API error as JSON.
+        if ($status === 400 && str_contains($body, "'key' is missing")) {
+            return InvalidApiKeyException::missing($response);
+        }
+
+        if ($status === 403 && str_contains($body, 'key=')) {
+            return InvalidApiKeyException::rejected($response);
+        }
+
+        return match ($status) {
+            401, 403 => ProfileNotPublicException::fromResponse($response),
+            default => new SteamApiException(
+                sprintf('Steam API request failed with HTTP %d.', $status),
+                $response,
+            ),
+        };
     }
 
     /**

--- a/tests/Feature/Http/Requests/IPlayerService/GetOwnedGamesRequestTest.php
+++ b/tests/Feature/Http/Requests/IPlayerService/GetOwnedGamesRequestTest.php
@@ -11,7 +11,7 @@ use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 
-covers([GetOwnedGamesRequest::class, OwnedGame::class]);
+covers([GetOwnedGamesRequest::class, OwnedGame::class, ProfileNotPublicException::class]);
 
 function ownedGamesConnector(): SteamConnector
 {
@@ -118,4 +118,4 @@ test('private profile throws ProfileNotPublicException', function (): void {
     $connector->withMockClient($mock);
 
     $connector->send(new GetOwnedGamesRequest(testSteamId()))->dto();
-})->throws(ProfileNotPublicException::class, 'Steam profile is not public.');
+})->throws(ProfileNotPublicException::class, 'Steam profile 76561198000000000 is not public.');

--- a/tests/Feature/Http/Requests/ISteamUser/GetUserGroupListRequestTest.php
+++ b/tests/Feature/Http/Requests/ISteamUser/GetUserGroupListRequestTest.php
@@ -67,7 +67,7 @@ test('membership-free fixture returns empty list', function (): void {
     expect($dtos)->toBeEmpty();
 });
 
-test('response without a success flag throws ProfileNotPublicException', function (): void {
+test('response without a groups key yields an empty list', function (): void {
     $mock = new MockClient([
         GetUserGroupListRequest::class => MockResponse::make(['response' => []]),
     ]);
@@ -75,8 +75,8 @@ test('response without a success flag throws ProfileNotPublicException', functio
     $connector = userGroupListConnector();
     $connector->withMockClient($mock);
 
-    $connector->send(new GetUserGroupListRequest(userGroupTestSteamId()))->dto();
-})->throws(ProfileNotPublicException::class, 'Steam profile is not public.');
+    expect($connector->send(new GetUserGroupListRequest(userGroupTestSteamId()))->dto())->toBeEmpty();
+});
 
 test('private profile throws ProfileNotPublicException', function (): void {
     $mock = new MockClient([

--- a/tests/Feature/Http/Requests/ISteamUserStats/GetPlayerAchievementsRequestTest.php
+++ b/tests/Feature/Http/Requests/ISteamUserStats/GetPlayerAchievementsRequestTest.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 use Fkrzski\SteamApiSdk\Dto\PlayerAchievement;
 use Fkrzski\SteamApiSdk\Dto\PlayerAchievements;
-use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
+use Fkrzski\SteamApiSdk\Exceptions\InvalidApiKeyException;
+use Fkrzski\SteamApiSdk\Exceptions\StatsUnavailableException;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetPlayerAchievementsRequest;
 use Fkrzski\SteamApiSdk\SteamConfig;
 use Fkrzski\SteamApiSdk\SteamConnector;
@@ -12,7 +13,7 @@ use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 
-covers([GetPlayerAchievementsRequest::class, PlayerAchievements::class, PlayerAchievement::class]);
+covers([GetPlayerAchievementsRequest::class, PlayerAchievements::class, PlayerAchievement::class, StatsUnavailableException::class]);
 
 function playerAchievementsConnector(): SteamConnector
 {
@@ -118,13 +119,24 @@ test('achievement without localized data has null name and description', functio
         ->and($dto->achievements[0]->description)->toBeNull();
 });
 
-test('private profile throws ProfileNotPublicException', function (): void {
+test('a 400 caused by a missing key is left to the connector, not read as a bad appid', function (): void {
     $mock = new MockClient([
-        GetPlayerAchievementsRequest::class => MockResponse::fixture('ISteamUserStats/GetPlayerAchievements/private'),
+        GetPlayerAchievementsRequest::class => MockResponse::fixture('Errors/missing-key'),
     ]);
 
     $connector = playerAchievementsConnector();
     $connector->withMockClient($mock);
 
     $connector->send(new GetPlayerAchievementsRequest(playerAchievementsSteamId(), 381210))->dto();
-})->throws(ProfileNotPublicException::class, 'Steam profile is not public.');
+})->throws(InvalidApiKeyException::class, 'Steam API key is missing. Check the key passed to SteamConfig.');
+
+test('a private profile and an app without stats are reported identically', function (): void {
+    $mock = new MockClient([
+        GetPlayerAchievementsRequest::class => MockResponse::fixture('ISteamUserStats/GetPlayerAchievements/stats-unavailable'),
+    ]);
+
+    $connector = playerAchievementsConnector();
+    $connector->withMockClient($mock);
+
+    $connector->send(new GetPlayerAchievementsRequest(playerAchievementsSteamId(), 381210))->dto();
+})->throws(StatsUnavailableException::class, 'Steam returned no stats for app 381210: it exposes none, or the profile is private.');

--- a/tests/Feature/Http/Requests/ISteamUserStats/GetUserStatsForGameRequestTest.php
+++ b/tests/Feature/Http/Requests/ISteamUserStats/GetUserStatsForGameRequestTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Fkrzski\SteamApiSdk\Dto\UserStat;
 use Fkrzski\SteamApiSdk\Dto\UserStatAchievement;
 use Fkrzski\SteamApiSdk\Dto\UserStats;
+use Fkrzski\SteamApiSdk\Exceptions\InvalidApiKeyException;
 use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetUserStatsForGameRequest;
 use Fkrzski\SteamApiSdk\SteamConfig;
@@ -101,4 +102,26 @@ test('private profile throws ProfileNotPublicException', function (): void {
     $connector->withMockClient($mock);
 
     $connector->send(new GetUserStatsForGameRequest(userStatsSteamId(), 381210))->dto();
+})->throws(ProfileNotPublicException::class, 'Steam profile 76561198148125221 is not public.');
+
+test('a 403 from Steam maps to ProfileNotPublicException via the connector', function (): void {
+    $mock = new MockClient([
+        GetUserStatsForGameRequest::class => MockResponse::make(['playerstats' => ['success' => false]], 403),
+    ]);
+
+    $connector = userStatsConnector();
+    $connector->withMockClient($mock);
+
+    $connector->send(new GetUserStatsForGameRequest(userStatsSteamId(), 381210))->dto();
 })->throws(ProfileNotPublicException::class, 'Steam profile is not public.');
+
+test('a 400 caused by a missing key is left to the connector', function (): void {
+    $mock = new MockClient([
+        GetUserStatsForGameRequest::class => MockResponse::fixture('Errors/missing-key'),
+    ]);
+
+    $connector = userStatsConnector();
+    $connector->withMockClient($mock);
+
+    $connector->send(new GetUserStatsForGameRequest(userStatsSteamId(), 381210))->dto();
+})->throws(InvalidApiKeyException::class, 'Steam API key is missing. Check the key passed to SteamConfig.');

--- a/tests/Feature/SteamConnectorTest.php
+++ b/tests/Feature/SteamConnectorTest.php
@@ -2,13 +2,21 @@
 
 declare(strict_types=1);
 
+use Fkrzski\SteamApiSdk\Exceptions\InvalidApiKeyException;
+use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
+use Fkrzski\SteamApiSdk\Exceptions\SteamApiException;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetFriendListRequest;
 use Fkrzski\SteamApiSdk\SteamConfig;
 use Fkrzski\SteamApiSdk\SteamConnector;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Saloon\Http\Faking\Fixture;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
 use Saloon\RateLimitPlugin\Limit;
 use Saloon\RateLimitPlugin\Stores\MemoryStore;
 use Saloon\Traits\Plugins\AlwaysThrowOnErrors;
 
-covers(SteamConnector::class);
+covers([SteamConnector::class, InvalidApiKeyException::class, ProfileNotPublicException::class]);
 
 test('base URL resolves to Steam Web API host', function (): void {
     $connector = new SteamConnector(new SteamConfig('any'));
@@ -51,4 +59,76 @@ test('resolveRateLimitStore falls back to a fresh in-memory store', function ():
     $rateLimitStore = $connector->rateLimitStore();
 
     expect($rateLimitStore)->toBeInstanceOf(MemoryStore::class);
+});
+
+/**
+ * Send through the connector so the failure travels the real middleware path.
+ */
+function sendFailing(MockResponse|Fixture $response): Throwable
+{
+    $connector = new SteamConnector(new SteamConfig('any'));
+    $connector->withMockClient(new MockClient([GetFriendListRequest::class => $response]));
+
+    try {
+        $connector->send(new GetFriendListRequest(SteamId::fromSteamId64('76561198148125221')));
+    } catch (Throwable $throwable) {
+        return $throwable;
+    }
+
+    throw new RuntimeException('Expected the request to fail.');
+}
+
+test('401 maps to ProfileNotPublicException', function (): void {
+    expect(sendFailing(MockResponse::make([], 401)))
+        ->toBeInstanceOf(ProfileNotPublicException::class)
+        ->and(sendFailing(MockResponse::make([], 401))->getMessage())->toBe('Steam profile is not public.');
+});
+
+test('403 carrying a JSON body maps to ProfileNotPublicException', function (): void {
+    expect(sendFailing(MockResponse::make(['playerstats' => ['success' => false]], 403)))
+        ->toBeInstanceOf(ProfileNotPublicException::class);
+});
+
+test('403 naming the key parameter maps to InvalidApiKeyException', function (): void {
+    $thrown = sendFailing(MockResponse::fixture('Errors/invalid-key'));
+
+    expect($thrown)->toBeInstanceOf(InvalidApiKeyException::class)
+        ->and($thrown->getMessage())->toBe('Steam rejected the API key. Check that it is valid and active.');
+});
+
+test('400 reporting a missing key maps to InvalidApiKeyException', function (): void {
+    $thrown = sendFailing(MockResponse::fixture('Errors/missing-key'));
+
+    expect($thrown)->toBeInstanceOf(InvalidApiKeyException::class)
+        ->and($thrown->getMessage())->toBe('Steam API key is missing. Check the key passed to SteamConfig.');
+});
+
+test('400 unrelated to the key falls back to SteamApiException', function (): void {
+    $thrown = sendFailing(MockResponse::make(['error' => 'whatever'], 400));
+
+    expect($thrown)->toBeInstanceOf(SteamApiException::class)
+        ->and($thrown->getMessage())->toBe('Steam API request failed with HTTP 400.');
+});
+
+test('server errors fall back to SteamApiException', function (): void {
+    $thrown = sendFailing(MockResponse::make('<html>Server Error</html>', 500));
+
+    expect($thrown)->toBeInstanceOf(SteamApiException::class)
+        ->and($thrown->getMessage())->toBe('Steam API request failed with HTTP 500.');
+});
+
+test('mapped exceptions carry the status code and the originating response', function (): void {
+    /** @var SteamApiException $thrown */
+    $thrown = sendFailing(MockResponse::make([], 401));
+
+    expect($thrown->getCode())->toBe(401)
+        ->and($thrown->response)->not->toBeNull()
+        ->and($thrown->response?->status())->toBe(401);
+});
+
+test('every mapped failure stays inside the SDK exception hierarchy', function (): void {
+    expect(sendFailing(MockResponse::make([], 401)))->toBeInstanceOf(SteamApiException::class)
+        ->and(sendFailing(MockResponse::fixture('Errors/invalid-key')))->toBeInstanceOf(SteamApiException::class)
+        ->and(sendFailing(MockResponse::fixture('Errors/missing-key')))->toBeInstanceOf(SteamApiException::class)
+        ->and(sendFailing(MockResponse::make('', 503)))->toBeInstanceOf(SteamApiException::class);
 });

--- a/tests/Fixtures/Saloon/Errors/invalid-key.json
+++ b/tests/Fixtures/Saloon/Errors/invalid-key.json
@@ -1,0 +1,7 @@
+{
+    "statusCode": 403,
+    "headers": {
+        "Content-Type": "text/html; charset=UTF-8"
+    },
+    "data": "<html>\n    <head>\n        <title>Forbidden</title>\n    </head>\n    <body>\n        <h1>Forbidden</h1>\n        Access is denied. Retrying will not help. Please verify your <pre>key=</pre>\n        parameter.\n    </body>\n</html>"
+}

--- a/tests/Fixtures/Saloon/Errors/missing-key.json
+++ b/tests/Fixtures/Saloon/Errors/missing-key.json
@@ -1,0 +1,7 @@
+{
+    "statusCode": 400,
+    "headers": {
+        "Content-Type": "text/html; charset=UTF-8"
+    },
+    "data": "<html>\n    <head>\n        <title>Bad Request</title>\n    </head>\n    <body>\n        <h1>Bad Request</h1>\n        Required parameter 'key' is missing\n    </body>\n</html>"
+}

--- a/tests/Fixtures/Saloon/ISteamUser/GetUserGroupList/private.json
+++ b/tests/Fixtures/Saloon/ISteamUser/GetUserGroupList/private.json
@@ -1,5 +1,5 @@
 {
-    "statusCode": 200,
+    "statusCode": 403,
     "headers": {
         "Content-Type": "application/json; charset=UTF-8"
     },

--- a/tests/Fixtures/Saloon/ISteamUserStats/GetPlayerAchievements/stats-unavailable.json
+++ b/tests/Fixtures/Saloon/ISteamUserStats/GetPlayerAchievements/stats-unavailable.json
@@ -1,11 +1,11 @@
 {
-    "statusCode": 200,
+    "statusCode": 400,
     "headers": {
         "Content-Type": "application/json; charset=UTF-8"
     },
     "data": {
         "playerstats": {
-            "error": "Profile is not public",
+            "error": "Requested app has no stats",
             "success": false
         }
     }

--- a/tests/Fixtures/Saloon/ISteamUserStats/GetUserStatsForGame/private.json
+++ b/tests/Fixtures/Saloon/ISteamUserStats/GetUserStatsForGame/private.json
@@ -1,5 +1,5 @@
 {
-    "statusCode": 200,
+    "statusCode": 400,
     "headers": {
         "Content-Type": "application/json; charset=UTF-8"
     },


### PR DESCRIPTION
Closes #20.

## Summary

Maps Steam's HTTP failures onto the SDK exception hierarchy through `getRequestException()`, so no Saloon exception reaches callers. Adds `InvalidApiKeyException` and `StatsUnavailableException`, and gives every exception the response that caused it.

## Why

`AlwaysThrowOnErrors` raised Saloon's `RequestException` subclasses, making the "every SDK failure extends `SteamApiException`" contract in `docs/guide.md` false. Three private-profile checks were unreachable behind an error status and had never run in production.

## Notes on the implementation

**Not `resolveResponseClass()`, as the issue proposed.** The endpoints share no response envelope and no success signal, so a shared parser would need per-request configuration for what `createDtoFromResponse()` already states plainly. Reasoning in the [issue comment](https://github.com/fkrzski/php-steam-api-sdk/issues/20#issuecomment-5307095135).

**The connector handles status, the request handles body.** Saloon consults the request first, so endpoint-specific statuses stay next to their endpoint and `return null` hands everything else to the connector. A request must claim a status only when it can positively identify its own payload — otherwise a missing API key gets reported as a bad appid.

**Key errors are the one case Steam answers with HTML.** Every real API failure is JSON, which is what separates a rejected key (403) and a missing one (400) from a private profile on the same status.

**`GetPlayerAchievements` cannot name its cause.** Steam returns a byte-identical `Requested app has no stats` body for an app without achievements and for a private profile, so `StatsUnavailableException` states both rather than guessing. `GetUserStatsForGame` answers an empty object for a private profile, which is unambiguous and maps to `ProfileNotPublicException`.

**429 is deliberately unmapped.** The rate limit plugin registers as `PipeOrder::FIRST` and throws before `AlwaysThrowOnErrors` (`LAST`) reaches the mapper, so `SteamRateLimitException` is untouched.

**Three fixtures described responses Steam does not send.** Private-profile fixtures claimed HTTP 200 for `GetPlayerAchievements`, `GetUserStatsForGame` and `GetUserGroupList`; measured against the live API they are 400, 400 and 403. Corrected, and the achievements pair collapsed into one file since both cases are identical on the wire. `GetOwnedGames` remains unverified — its 200 guard and the connector cover both possibilities either way.

**`ProfileNotPublicException` messages moved behind named constructors** so the same failure reads the same way at every throw site.

## Checks

`composer test` passes end to end: pint, rector, phpstan, profanity, 149 tests / 318 assertions, 100% coverage, 100% type coverage, and 181/181 mutants killed (MSI 100%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
