### PR TITLE
fix: scope rate limit counter to the API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `PlayerSummary` can now be passed to `json_encode()`. Both enums it exposes were pure, and PHP has no default serialization for those, so encoding a `PlayerSummary` — or any structure containing one — returned `false` with `Non-backed enums have no default serialization`. See [#25](https://github.com/fkrzski/php-steam-api-sdk/issues/25); `DateTimeImmutable` properties still serialize as PHP's internal shape and remain open there.
 - `SteamId::tryFromInput()` and `SteamId::extractVanityName()` now parse profile and vanity URLs that carry a sub-path, query string or fragment (e.g. `/profiles/<id>/stats/`, `/id/<nick>?snr=…`). Previously the trailing segment made `tryFromInput()` return `null`, while `extractVanityName()` silently returned an unusable slug.
+- Rate limit counters are now scoped to the API key instead of being shared by every connector in the process, so one key can no longer spend another's daily budget. The key is hashed into the store key, never written in plaintext. Counters already held in a persistent store use the old key format and restart from zero once. Closes [#30](https://github.com/fkrzski/php-steam-api-sdk/issues/30).
 
 ## [0.3.0] - 2026-07-30
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,6 +37,12 @@ The Steam Web API allows **100 000 requests per API key per day**. The connector
 enforces this via [`saloonphp/rate-limit-plugin`](https://github.com/saloonphp/rate-limit-plugin)
 and throws `SteamRateLimitException` once the budget is spent.
 
+## Multiple API keys
+
+The budget is tracked per API key, so a process — or a shared store — can serve several
+keys without them draining each other's quota. Only a SHA-256 hash of the key ever
+reaches the store.
+
 ## Sharing the budget across processes
 
 The default `MemoryStore` only tracks usage within a single PHP process — fine for a

--- a/src/SteamConnector.php
+++ b/src/SteamConnector.php
@@ -80,9 +80,22 @@ class SteamConnector extends Connector
         ];
     }
 
+    /**
+     * MemoryStore keeps its backing array static, so the default budget is shared
+     * process-wide rather than per instance.
+     */
     protected function resolveRateLimitStore(): RateLimitStore
     {
         return $this->steamConfig->rateLimitStore ?? new MemoryStore;
+    }
+
+    /**
+     * The quota belongs to the API key, not to the connector class. The key is hashed
+     * so it never lands in a shared store.
+     */
+    protected function getLimiterPrefix(): ?string
+    {
+        return sprintf('SteamConnector:%s', hash('sha256', $this->steamConfig->apiKey));
     }
 
     protected function throwLimitException(Limit $limit): void

--- a/tests/Feature/RateLimitTest.php
+++ b/tests/Feature/RateLimitTest.php
@@ -42,6 +42,37 @@ test('connector honours the configured rate limit store', function (): void {
     expect($connector->rateLimitStore())->toBe($store);
 });
 
+test('limits are keyed by a hash of the API key', function (): void {
+    $connector = new SteamConnector(new SteamConfig('test-key'));
+
+    $names = array_map(
+        static fn (Limit $limit): string => $limit->getName(),
+        $connector->getLimits(),
+    );
+
+    expect($names)->toBe([
+        'SteamConnector:62af8704764faf8ea82fc61ce9c4c3908b6cb97d463a634e9e587d7c885db0ef:100000_every_86400',
+        'SteamConnector:62af8704764faf8ea82fc61ce9c4c3908b6cb97d463a634e9e587d7c885db0ef:too_many_attempts_limit',
+    ])->and(implode('', $names))->not->toContain('test-key');
+});
+
+test('each API key gets its own counter', function (): void {
+    $first = sendVanityUrlRequest('key-aaa');
+    $second = sendVanityUrlRequest('key-bbb');
+
+    expect(dailyLimitKeys())->toHaveCount(2)
+        ->and(dailyHits($first))->toBe(1)
+        ->and(dailyHits($second))->toBe(1);
+});
+
+test('connectors sharing an API key share one counter', function (): void {
+    sendVanityUrlRequest('key-aaa');
+    $second = sendVanityUrlRequest('key-aaa');
+
+    expect(dailyLimitKeys())->toHaveCount(1)
+        ->and(dailyHits($second))->toBe(2);
+});
+
 test('hitting the limit throws SteamRateLimitException with the offending limit', function (): void {
     $connector = new class(new SteamConfig('test-key')) extends SteamConnector
     {
@@ -70,3 +101,32 @@ test('hitting the limit throws SteamRateLimitException with the offending limit'
             ->and($steamRateLimitException->getMessage())->toContain('Steam API rate limit reached');
     }
 });
+
+function sendVanityUrlRequest(string $apiKey): SteamConnector
+{
+    $connector = new SteamConnector(new SteamConfig($apiKey));
+
+    $connector->withMockClient(new MockClient([
+        ResolveVanityUrlRequest::class => MockResponse::fixture('ISteamUser/ResolveVanityUrl/success'),
+    ]));
+
+    $connector->send(new ResolveVanityUrlRequest('nick'));
+
+    return $connector;
+}
+
+/**
+ * @return list<string>
+ */
+function dailyLimitKeys(): array
+{
+    return array_values(array_filter(
+        array_keys((new MemoryStore)->getStore()),
+        static fn (string $key): bool => str_ends_with($key, '100000_every_86400'),
+    ));
+}
+
+function dailyHits(SteamConnector $connector): int
+{
+    return $connector->getLimits()[0]->update($connector->rateLimitStore())->getHits();
+}


### PR DESCRIPTION
Closes #30.

## Summary

Scopes the rate limiter prefix to a SHA-256 hash of the configured API key, so each key gets its own 100 000/day budget instead of every connector in the process sharing one counter.

## Why

`getLimiterPrefix()` derived the limit name from the connector class alone, so nothing distinguished one `SteamConfig::$apiKey` from another. With a persistent store — the documented multi-tenant setup — every tenant merged into one counter permanently and started receiving `SteamRateLimitException` long before their own key was spent.

## Notes on the implementation

**Hashed, not raw.** The prefix ends up in store keys, so a raw key would be written in plaintext into Redis or PSR-6 and into any key dump. SHA-256 rather than the `xxh128` the issue suggested: the input is a secret, and a non-cryptographic hash gives no preimage resistance.

**`SteamConnector` as a literal, not `getShortName()`.** The quota belongs to the key, not the class, so a subclass configured with the same key has to share the budget. It also stops anonymous subclasses from writing absolute file paths into store keys.

**`MemoryStore` stays the default.** Its static backing array is the correct semantic for a process-wide daily quota — a per-instance store would reset the counter on every new connector. Noted in a docblock rather than swapped out.

**Store keys change format.** Counters already held in a persistent store are orphaned and restart from zero once.

## Checks

`composer test` passes end to end: pint, rector, phpstan, profanity, 152 tests / 325 assertions, 100% coverage, 100% type coverage, and 182/182 mutants killed (MSI 100%).
