### PR TITLE
feat: add GetRecentlyPlayedGames endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `GetRecentlyPlayedGamesRequest` (`IPlayerService`) with the `RecentlyPlayedGames` and `RecentlyPlayedGame` DTOs and an optional `count` limit. `RecentlyPlayedGames::$totalCount` carries Steam's unlimited total, so a list truncated by `count` stays distinguishable from a complete one ([#36](https://github.com/fkrzski/php-steam-api-sdk/issues/36)).
 - Testing guidance in the docs: faking the connector with Saloon's `MockClient`, and clearing the `MemoryStore` daily counter between tests.
 
 ### Changed

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -22,6 +22,7 @@ tells you which part of the Web API you are talking to:
 - src/Http/Requests
   - IPlayerService
     - GetOwnedGamesRequest.php
+    - GetRecentlyPlayedGamesRequest.php
   - ISteamUser
     - GetFriendListRequest.php
     - GetPlayerBansRequest.php
@@ -41,6 +42,7 @@ tells you which part of the Web API you are talking to:
 | [`GetPlayerAchievementsRequest`](#getplayerachievementsrequest) | `PlayerAchievements` |
 | [`GetPlayerBansRequest`](#getplayerbansrequest) | `list<PlayerBan>` |
 | [`GetPlayerSummariesRequest`](#getplayersummariesrequest) | `list<PlayerSummary>` |
+| [`GetRecentlyPlayedGamesRequest`](#getrecentlyplayedgamesrequest) | `RecentlyPlayedGames` |
 | [`GetUserGroupListRequest`](#getusergrouplistrequest) | `list<UserGroup>` |
 | [`GetUserStatsForGameRequest`](#getuserstatsforgamerequest) | `UserStats` |
 | [`ResolveVanityUrlRequest`](#resolvevanityurlrequest) | `SteamId` |
@@ -170,6 +172,37 @@ foreach ($summaries as $summary) {
     echo $summary->personaName, ' — ', $summary->profileUrl, PHP_EOL;
 }
 ```
+
+## GetRecentlyPlayedGamesRequest
+
+```text frame="none"
+new GetRecentlyPlayedGamesRequest(SteamId $steamId, ?int $count = null)
+```
+
+<p><Badge text="IPlayerService" variant="note" size="small" />{' '}<Badge text="throws ProfileNotPublicException" variant="danger" size="small" /></p>
+
+What a player launched in the last two weeks. `count` caps how many games come back,
+while `totalCount` on the result stays the full figure — that is how you tell a truncated
+list from a complete one.
+
+```php "count: 2"
+use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetRecentlyPlayedGamesRequest;
+
+$recent = $connector->send(new GetRecentlyPlayedGamesRequest(
+    steamId: $steamId,
+    count: 2,
+))->dto();
+
+foreach ($recent->games as $game) {
+    echo $game->name, ' — ', $game->playtimeTwoWeeks, ' min', PHP_EOL;
+}
+```
+
+<Aside type="caution" title="An idle player is not a failure">
+A player who launched nothing comes back as `totalCount: 0` with an empty `games` list.
+The exception is reserved for the payload Steam withholds, which it sends both for a
+hidden profile and for a SteamID64 that belongs to no account.
+</Aside>
 
 ## GetUserGroupListRequest
 

--- a/docs/dto-reference.mdx
+++ b/docs/dto-reference.mdx
@@ -106,6 +106,29 @@ When `communityVisibility` is `Hidden`, Steam sends only the identity and avatar
 back `null`, and a mixed batch returns those summaries alongside the public ones.
 </Aside>
 
+## RecentlyPlayedGames
+
+Returned by [`GetRecentlyPlayedGamesRequest`](/php-steam-api-sdk/api-reference#getrecentlyplayedgamesrequest).
+
+| Property | Type | Notes |
+| --- | --- | --- |
+| `totalCount` | `int` | Unique games played in the last two weeks, ignoring `count`. |
+| `games` | `list<RecentlyPlayedGame>` | Per-game playtime, capped by `count`. |
+
+Each `RecentlyPlayedGame` carries:
+
+| Property | Type | Notes |
+| --- | --- | --- |
+| `appId` | `int` | Steam app ID. |
+| `name` | `string` | Game title. |
+| `playtimeTwoWeeks` | `int` | Playtime in the last two weeks, in minutes. |
+| `playtimeForever` | `int` | Total playtime, in minutes. |
+| `imgIconUrl` | `string` | Icon hash. |
+| `playtimeWindowsForever` | `int` | Total playtime on Windows, in minutes. |
+| `playtimeMacForever` | `int` | Total playtime on macOS, in minutes. |
+| `playtimeLinuxForever` | `int` | Total playtime on Linux, in minutes. |
+| `playtimeDeckForever` | `int` | Total playtime on Steam Deck, in minutes. |
+
 ## UserGroup
 
 Returned by [`GetUserGroupListRequest`](/php-steam-api-sdk/api-reference#getusergrouplistrequest).

--- a/docs/guide.mdx
+++ b/docs/guide.mdx
@@ -170,10 +170,11 @@ Steam overloads `400` across unrelated causes. Key errors are the one case it an
 with HTML rather than JSON — that is what keeps a misconfigured key from surfacing as a
 data problem.
 
-<Aside type="caution" title="One endpoint answers ambiguously">
-`GetPlayerAchievements` returns a byte-identical `Requested app has no stats` body for
-an app without achievements and for a private profile, so `StatsUnavailableException`
-names both causes rather than guessing.
+<Aside type="caution" title="Two endpoints answer ambiguously">
+`GetPlayerAchievements` returns a byte-identical `Requested app has no stats` body for an
+app without achievements and for a private profile. `GetRecentlyPlayedGames` returns an
+empty payload both for a hidden profile and for a SteamID64 that belongs to no account.
+Both messages name every cause rather than guessing.
 </Aside>
 
 ## Testing

--- a/src/Dto/RecentlyPlayedGame.php
+++ b/src/Dto/RecentlyPlayedGame.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Dto;
+
+final readonly class RecentlyPlayedGame
+{
+    public function __construct(
+        public int $appId,
+        public string $name,
+        public int $playtimeTwoWeeks,
+        public int $playtimeForever,
+        public string $imgIconUrl,
+        public int $playtimeWindowsForever,
+        public int $playtimeMacForever,
+        public int $playtimeLinuxForever,
+        public int $playtimeDeckForever,
+    ) {}
+
+    /**
+     * @param  array{
+     *     appid: int,
+     *     name: string,
+     *     playtime_2weeks: int,
+     *     playtime_forever: int,
+     *     img_icon_url: string,
+     *     playtime_windows_forever: int,
+     *     playtime_mac_forever: int,
+     *     playtime_linux_forever: int,
+     *     playtime_deck_forever: int,
+     * }  $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        return new self(
+            appId: $payload['appid'],
+            name: $payload['name'],
+            playtimeTwoWeeks: $payload['playtime_2weeks'],
+            playtimeForever: $payload['playtime_forever'],
+            imgIconUrl: $payload['img_icon_url'],
+            playtimeWindowsForever: $payload['playtime_windows_forever'],
+            playtimeMacForever: $payload['playtime_mac_forever'],
+            playtimeLinuxForever: $payload['playtime_linux_forever'],
+            playtimeDeckForever: $payload['playtime_deck_forever'],
+        );
+    }
+}

--- a/src/Dto/RecentlyPlayedGames.php
+++ b/src/Dto/RecentlyPlayedGames.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Dto;
+
+final readonly class RecentlyPlayedGames
+{
+    /**
+     * @param  list<RecentlyPlayedGame>  $games
+     */
+    public function __construct(
+        public int $totalCount,
+        public array $games,
+    ) {}
+
+    /**
+     * @param  array{total_count: int, games?: list<array{
+     *     appid: int,
+     *     name: string,
+     *     playtime_2weeks: int,
+     *     playtime_forever: int,
+     *     img_icon_url: string,
+     *     playtime_windows_forever: int,
+     *     playtime_mac_forever: int,
+     *     playtime_linux_forever: int,
+     *     playtime_deck_forever: int,
+     * }>}  $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        return new self(
+            totalCount: $payload['total_count'],
+            games: array_map(RecentlyPlayedGame::fromArray(...), $payload['games'] ?? []),
+        );
+    }
+}

--- a/src/Exceptions/ProfileNotPublicException.php
+++ b/src/Exceptions/ProfileNotPublicException.php
@@ -15,6 +15,18 @@ final class ProfileNotPublicException extends SteamApiException
     }
 
     /**
+     * Steam answers HTTP 200 with an empty `response` object both for a hidden profile
+     * and for a SteamID64 that belongs to no account, so the cause cannot be recovered.
+     */
+    public static function forPrivateOrMissing(SteamId $steamId, ?Response $response = null): self
+    {
+        return new self(
+            sprintf('Steam returned no data for profile %s: it is not public, or it does not exist.', $steamId),
+            $response,
+        );
+    }
+
+    /**
      * Used where the profile is not known, such as status mapping on the connector.
      */
     public static function fromResponse(Response $response): self

--- a/src/Http/Requests/IPlayerService/GetRecentlyPlayedGamesRequest.php
+++ b/src/Http/Requests/IPlayerService/GetRecentlyPlayedGamesRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Http\Requests\IPlayerService;
+
+use Fkrzski\SteamApiSdk\Dto\RecentlyPlayedGames;
+use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Override;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+final class GetRecentlyPlayedGamesRequest extends Request
+{
+    #[Override]
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        public readonly SteamId $steamId,
+        public readonly ?int $count = null,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return '/IPlayerService/GetRecentlyPlayedGames/v1/';
+    }
+
+    public function createDtoFromResponse(Response $response): RecentlyPlayedGames
+    {
+        /**
+         * @var array{response?: array{total_count: int, games?: list<array{
+         *     appid: int,
+         *     name: string,
+         *     playtime_2weeks: int,
+         *     playtime_forever: int,
+         *     img_icon_url: string,
+         *     playtime_windows_forever: int,
+         *     playtime_mac_forever: int,
+         *     playtime_linux_forever: int,
+         *     playtime_deck_forever: int,
+         * }>}} $body
+         */
+        $body = $response->json();
+        $responseBody = $body['response'] ?? [];
+
+        // A player with nothing played still gets `total_count: 0`; only a withheld
+        // profile drops the key, which makes its absence the discriminator.
+        if (! array_key_exists('total_count', $responseBody)) {
+            throw ProfileNotPublicException::forPrivateOrMissing($this->steamId, $response);
+        }
+
+        return RecentlyPlayedGames::fromArray($responseBody);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function defaultQuery(): array
+    {
+        $query = ['steamid' => $this->steamId->value];
+
+        if ($this->count !== null) {
+            $query['count'] = $this->count;
+        }
+
+        return $query;
+    }
+}

--- a/tests/Feature/Http/Requests/IPlayerService/GetRecentlyPlayedGamesRequestTest.php
+++ b/tests/Feature/Http/Requests/IPlayerService/GetRecentlyPlayedGamesRequestTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use Fkrzski\SteamApiSdk\Dto\RecentlyPlayedGame;
+use Fkrzski\SteamApiSdk\Dto\RecentlyPlayedGames;
+use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
+use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetRecentlyPlayedGamesRequest;
+use Fkrzski\SteamApiSdk\SteamConfig;
+use Fkrzski\SteamApiSdk\SteamConnector;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+covers([
+    GetRecentlyPlayedGamesRequest::class,
+    RecentlyPlayedGames::class,
+    RecentlyPlayedGame::class,
+    ProfileNotPublicException::class,
+]);
+
+function recentlyPlayedSteamId(): SteamId
+{
+    return SteamId::fromSteamId64('76561198000000000');
+}
+
+function sendRecentlyPlayedFixture(string $fixture, ?int $count = null): RecentlyPlayedGames
+{
+    $connector = new SteamConnector(new SteamConfig('test-key'));
+    $connector->withMockClient(new MockClient([
+        GetRecentlyPlayedGamesRequest::class => MockResponse::fixture(
+            sprintf('IPlayerService/GetRecentlyPlayedGames/%s', $fixture),
+        ),
+    ]));
+
+    /** @var RecentlyPlayedGames $dto */
+    $dto = $connector->send(new GetRecentlyPlayedGamesRequest(recentlyPlayedSteamId(), $count))->dto();
+
+    return $dto;
+}
+
+test('endpoint targets GetRecentlyPlayedGames v1', function (): void {
+    $request = new GetRecentlyPlayedGamesRequest(recentlyPlayedSteamId());
+
+    expect($request->resolveEndpoint())->toBe('/IPlayerService/GetRecentlyPlayedGames/v1/');
+});
+
+test('query includes steamid', function (): void {
+    $request = new GetRecentlyPlayedGamesRequest(recentlyPlayedSteamId());
+
+    expect($request->query()->all())->toMatchArray(['steamid' => '76561198000000000']);
+});
+
+test('query includes count when provided', function (): void {
+    $request = new GetRecentlyPlayedGamesRequest(recentlyPlayedSteamId(), 2);
+
+    expect($request->query()->all())->toMatchArray(['count' => 2]);
+});
+
+test('query omits count by default', function (): void {
+    $request = new GetRecentlyPlayedGamesRequest(recentlyPlayedSteamId());
+
+    expect($request->query()->all())->not->toHaveKey('count');
+});
+
+test('fixture response parses into RecentlyPlayedGame DTOs', function (): void {
+    $dto = sendRecentlyPlayedFixture('default');
+
+    expect($dto)->toBeInstanceOf(RecentlyPlayedGames::class)
+        ->and($dto->totalCount)->toBe(3)
+        ->and($dto->games)->toHaveCount(3)
+        ->and($dto->games[0])->toBeInstanceOf(RecentlyPlayedGame::class)
+        ->and($dto->games[0]->appId)->toBe(220260)
+        ->and($dto->games[0]->name)->toBe('Farming Simulator 2013: Titanium Edition')
+        ->and($dto->games[0]->playtimeTwoWeeks)->toBe(1975)
+        ->and($dto->games[0]->playtimeForever)->toBe(6583)
+        ->and($dto->games[0]->imgIconUrl)->toBe('79a6827ff70f6e6ccfb7878e548011b6805c0143')
+        ->and($dto->games[0]->playtimeWindowsForever)->toBe(6583)
+        ->and($dto->games[0]->playtimeMacForever)->toBe(0)
+        ->and($dto->games[0]->playtimeLinuxForever)->toBe(0)
+        ->and($dto->games[0]->playtimeDeckForever)->toBe(0)
+        ->and($dto->games[1]->playtimeLinuxForever)->toBe(89);
+});
+
+test('totalCount keeps the unlimited total when count truncates the list', function (): void {
+    $dto = sendRecentlyPlayedFixture('limited', 2);
+
+    expect($dto->games)->toHaveCount(2)
+        ->and($dto->totalCount)->toBe(3);
+});
+
+test('nothing played in two weeks returns a zeroed total and no games', function (): void {
+    $dto = sendRecentlyPlayedFixture('empty');
+
+    expect($dto->totalCount)->toBe(0)
+        ->and($dto->games)->toBeEmpty();
+});
+
+test('withheld profile throws ProfileNotPublicException naming both causes', function (): void {
+    sendRecentlyPlayedFixture('private');
+})->throws(
+    ProfileNotPublicException::class,
+    'Steam returned no data for profile 76561198000000000: it is not public, or it does not exist.',
+);

--- a/tests/Fixtures/Saloon/IPlayerService/GetRecentlyPlayedGames/default.json
+++ b/tests/Fixtures/Saloon/IPlayerService/GetRecentlyPlayedGames/default.json
@@ -1,0 +1,46 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "response": {
+            "total_count": 3,
+            "games": [
+                {
+                    "appid": 220260,
+                    "name": "Farming Simulator 2013: Titanium Edition",
+                    "playtime_2weeks": 1975,
+                    "playtime_forever": 6583,
+                    "img_icon_url": "79a6827ff70f6e6ccfb7878e548011b6805c0143",
+                    "playtime_windows_forever": 6583,
+                    "playtime_mac_forever": 0,
+                    "playtime_linux_forever": 0,
+                    "playtime_deck_forever": 0
+                },
+                {
+                    "appid": 566160,
+                    "name": "Zup! 6",
+                    "playtime_2weeks": 89,
+                    "playtime_forever": 220,
+                    "img_icon_url": "09e6bef7c6511478bda53be512e777dd0be06295",
+                    "playtime_windows_forever": 130,
+                    "playtime_mac_forever": 0,
+                    "playtime_linux_forever": 89,
+                    "playtime_deck_forever": 0
+                },
+                {
+                    "appid": 658560,
+                    "name": "Zup! 7",
+                    "playtime_2weeks": 55,
+                    "playtime_forever": 154,
+                    "img_icon_url": "9e336842c3f7341772fe45694ac907f0df209534",
+                    "playtime_windows_forever": 99,
+                    "playtime_mac_forever": 0,
+                    "playtime_linux_forever": 55,
+                    "playtime_deck_forever": 0
+                }
+            ]
+        }
+    }
+}

--- a/tests/Fixtures/Saloon/IPlayerService/GetRecentlyPlayedGames/empty.json
+++ b/tests/Fixtures/Saloon/IPlayerService/GetRecentlyPlayedGames/empty.json
@@ -1,0 +1,11 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "response": {
+            "total_count": 0
+        }
+    }
+}

--- a/tests/Fixtures/Saloon/IPlayerService/GetRecentlyPlayedGames/limited.json
+++ b/tests/Fixtures/Saloon/IPlayerService/GetRecentlyPlayedGames/limited.json
@@ -1,0 +1,35 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "response": {
+            "total_count": 3,
+            "games": [
+                {
+                    "appid": 220260,
+                    "name": "Farming Simulator 2013: Titanium Edition",
+                    "playtime_2weeks": 1975,
+                    "playtime_forever": 6583,
+                    "img_icon_url": "79a6827ff70f6e6ccfb7878e548011b6805c0143",
+                    "playtime_windows_forever": 6583,
+                    "playtime_mac_forever": 0,
+                    "playtime_linux_forever": 0,
+                    "playtime_deck_forever": 0
+                },
+                {
+                    "appid": 566160,
+                    "name": "Zup! 6",
+                    "playtime_2weeks": 89,
+                    "playtime_forever": 220,
+                    "img_icon_url": "09e6bef7c6511478bda53be512e777dd0be06295",
+                    "playtime_windows_forever": 130,
+                    "playtime_mac_forever": 0,
+                    "playtime_linux_forever": 89,
+                    "playtime_deck_forever": 0
+                }
+            ]
+        }
+    }
+}

--- a/tests/Fixtures/Saloon/IPlayerService/GetRecentlyPlayedGames/private.json
+++ b/tests/Fixtures/Saloon/IPlayerService/GetRecentlyPlayedGames/private.json
@@ -1,0 +1,9 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "response": {}
+    }
+}


### PR DESCRIPTION
## Summary

`GetRecentlyPlayedGamesRequest` (`IPlayerService`) with the `RecentlyPlayedGames` and `RecentlyPlayedGame` DTOs, plus an optional `count` limit.

- `feat: add GetRecentlyPlayedGames endpoint` — the request, both DTOs, `ProfileNotPublicException::forPrivateOrMissing()`, four fixtures and their tests.
- `docs: document GetRecentlyPlayedGames endpoint` — API and DTO reference sections, the CHANGELOG entry, and the guide's ambiguity note now covering two endpoints instead of one.

## Why

Two shapes needed a decision, and both were settled against the live API rather than assumed:

- **A wrapper, not a bare list.** `total_count` stays at the unlimited total when `count` truncates the response, so it is the only thing that tells a capped list from a complete one. `GetOwnedGames` can return a bare list precisely because its `game_count` never carries that extra information.
- **The exception names two causes.** Steam answers `200` with an empty `response` object both for a withheld profile and for a well-formed SteamID64 that belongs to no account, so the message states both instead of guessing — the same treatment `StatsUnavailableException` already gets.

A player who simply has not launched anything is not a failure: that comes back as `total_count: 0` with the `games` key absent, which is what keeps the discriminator trustworthy.

Per-platform playtimes (`playtime_windows_forever` and its siblings) land on `RecentlyPlayedGame` but not on `OwnedGame`. Aligning the older DTO is out of scope here.

Closes #36
