### PR TITLE
feat: add GetSteamLevel endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `GetRecentlyPlayedGamesRequest` (`IPlayerService`) with the `RecentlyPlayedGames` and `RecentlyPlayedGame` DTOs and an optional `count` limit. `RecentlyPlayedGames::$totalCount` carries Steam's unlimited total, so a list truncated by `count` stays distinguishable from a complete one ([#36](https://github.com/fkrzski/php-steam-api-sdk/issues/36)).
+- `GetSteamLevelRequest` (`IPlayerService`) returning the player's Steam community level as a plain `int`. Level `0` is also what Steam answers for a SteamID64 that belongs to no account, so it is not treated as a failure ([#37](https://github.com/fkrzski/php-steam-api-sdk/issues/37)).
 - Testing guidance in the docs: faking the connector with Saloon's `MockClient`, and clearing the `MemoryStore` daily counter between tests.
 
 ### Changed

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -23,6 +23,7 @@ tells you which part of the Web API you are talking to:
   - IPlayerService
     - GetOwnedGamesRequest.php
     - GetRecentlyPlayedGamesRequest.php
+    - GetSteamLevelRequest.php
   - ISteamUser
     - GetFriendListRequest.php
     - GetPlayerBansRequest.php
@@ -43,6 +44,7 @@ tells you which part of the Web API you are talking to:
 | [`GetPlayerBansRequest`](#getplayerbansrequest) | `list<PlayerBan>` |
 | [`GetPlayerSummariesRequest`](#getplayersummariesrequest) | `list<PlayerSummary>` |
 | [`GetRecentlyPlayedGamesRequest`](#getrecentlyplayedgamesrequest) | `RecentlyPlayedGames` |
+| [`GetSteamLevelRequest`](#getsteamlevelrequest) | `int` |
 | [`GetUserGroupListRequest`](#getusergrouplistrequest) | `list<UserGroup>` |
 | [`GetUserStatsForGameRequest`](#getuserstatsforgamerequest) | `UserStats` |
 | [`ResolveVanityUrlRequest`](#resolvevanityurlrequest) | `SteamId` |
@@ -202,6 +204,29 @@ foreach ($recent->games as $game) {
 A player who launched nothing comes back as `totalCount: 0` with an empty `games` list.
 The exception is reserved for the payload Steam withholds, which it sends both for a
 hidden profile and for a SteamID64 that belongs to no account.
+</Aside>
+
+## GetSteamLevelRequest
+
+```text frame="none"
+new GetSteamLevelRequest(SteamId $steamId)
+```
+
+<p><Badge text="IPlayerService" variant="note" size="small" />{' '}<Badge text="throws ProfileNotPublicException" variant="danger" size="small" /></p>
+
+The player's Steam community level, as a plain `int` rather than a DTO. Hiding game
+details leaves it readable — only a profile Steam withholds altogether comes back empty,
+and that is what raises the exception.
+
+```php
+use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetSteamLevelRequest;
+
+$level = $connector->send(new GetSteamLevelRequest($steamId))->dto();
+```
+
+<Aside type="caution" title="Level 0 also answers for an account that does not exist">
+Steam reports level `0` for a SteamID64 belonging to no account, exactly as it does for a
+brand-new one. Nothing in the payload separates the two, so neither does the SDK.
 </Aside>
 
 ## GetUserGroupListRequest

--- a/src/Http/Requests/IPlayerService/GetSteamLevelRequest.php
+++ b/src/Http/Requests/IPlayerService/GetSteamLevelRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Http\Requests\IPlayerService;
+
+use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Override;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+final class GetSteamLevelRequest extends Request
+{
+    #[Override]
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        public readonly SteamId $steamId,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return '/IPlayerService/GetSteamLevel/v1/';
+    }
+
+    public function createDtoFromResponse(Response $response): int
+    {
+        /** @var array{response?: array{player_level?: int}} $body */
+        $body = $response->json();
+
+        // Level 0 is a real level, so only the missing key marks a withheld profile.
+        if (! isset($body['response']['player_level'])) {
+            throw ProfileNotPublicException::forSteamId($this->steamId, $response);
+        }
+
+        return $body['response']['player_level'];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function defaultQuery(): array
+    {
+        return [
+            'steamid' => $this->steamId->value,
+        ];
+    }
+}

--- a/tests/Feature/Http/Requests/IPlayerService/GetSteamLevelRequestTest.php
+++ b/tests/Feature/Http/Requests/IPlayerService/GetSteamLevelRequestTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
+use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetSteamLevelRequest;
+use Fkrzski\SteamApiSdk\SteamConfig;
+use Fkrzski\SteamApiSdk\SteamConnector;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+covers([GetSteamLevelRequest::class, ProfileNotPublicException::class]);
+
+function steamLevelSteamId(): SteamId
+{
+    return SteamId::fromSteamId64('76561198000000000');
+}
+
+function sendSteamLevelFixture(string $fixture): int
+{
+    $connector = new SteamConnector(new SteamConfig('test-key'));
+    $connector->withMockClient(new MockClient([
+        GetSteamLevelRequest::class => MockResponse::fixture(
+            sprintf('IPlayerService/GetSteamLevel/%s', $fixture),
+        ),
+    ]));
+
+    /** @var int $level */
+    $level = $connector->send(new GetSteamLevelRequest(steamLevelSteamId()))->dto();
+
+    return $level;
+}
+
+test('endpoint targets GetSteamLevel v1', function (): void {
+    $request = new GetSteamLevelRequest(steamLevelSteamId());
+
+    expect($request->resolveEndpoint())->toBe('/IPlayerService/GetSteamLevel/v1/');
+});
+
+test('query carries steamid parameter', function (): void {
+    $request = new GetSteamLevelRequest(steamLevelSteamId());
+
+    expect($request->query()->all())->toBe(['steamid' => '76561198000000000']);
+});
+
+test('fixture response yields the level as an int', function (): void {
+    expect(sendSteamLevelFixture('default'))->toBe(56);
+});
+
+test('level zero comes back as zero instead of throwing', function (): void {
+    expect(sendSteamLevelFixture('zero'))->toBe(0);
+});
+
+test('withheld profile throws ProfileNotPublicException', function (): void {
+    sendSteamLevelFixture('private');
+})->throws(
+    ProfileNotPublicException::class,
+    'Steam profile 76561198000000000 is not public.',
+);

--- a/tests/Fixtures/Saloon/IPlayerService/GetSteamLevel/default.json
+++ b/tests/Fixtures/Saloon/IPlayerService/GetSteamLevel/default.json
@@ -1,0 +1,11 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "response": {
+            "player_level": 56
+        }
+    }
+}

--- a/tests/Fixtures/Saloon/IPlayerService/GetSteamLevel/private.json
+++ b/tests/Fixtures/Saloon/IPlayerService/GetSteamLevel/private.json
@@ -1,0 +1,9 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "response": {}
+    }
+}

--- a/tests/Fixtures/Saloon/IPlayerService/GetSteamLevel/zero.json
+++ b/tests/Fixtures/Saloon/IPlayerService/GetSteamLevel/zero.json
@@ -1,0 +1,11 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "response": {
+            "player_level": 0
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `feat`: `GetSteamLevelRequest` (`IPlayerService`), returning the player's Steam community level as a plain `int`, with fixtures for a level, a zero and a withheld profile.
- `docs`: the endpoint in `docs/api-reference.mdx` and a CHANGELOG entry under Unreleased.

## Why

Probing the live endpoint turned up two behaviours worth pinning down:

- A profile Steam withholds entirely answers `{"response":{}}` — the same empty payload `GetOwnedGames` returns — so that case raises `ProfileNotPublicException`.
- A SteamID64 belonging to no account answers `player_level: 0`, identical to a brand-new account. Nothing in the payload separates them, so the SDK returns `0` rather than inventing an exception. A test covers it, since a falsy check here would silently turn a real level into a failure.

A single scalar does not earn a DTO, so the request returns a bare `int`, the way `ResolveVanityUrlRequest` returns a `SteamId`.

Closes #37
