### PR TITLE
feat: add GetBadges endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `GetBadgesRequest` (`IPlayerService`) with the `PlayerBadges` and `Badge` DTOs, covering every earned badge alongside the experience behind the community level. An account with no badges answers exactly like a SteamID64 that belongs to nobody, so neither is treated as a failure ([#38](https://github.com/fkrzski/php-steam-api-sdk/issues/38)).
 - `GetRecentlyPlayedGamesRequest` (`IPlayerService`) with the `RecentlyPlayedGames` and `RecentlyPlayedGame` DTOs and an optional `count` limit. `RecentlyPlayedGames::$totalCount` carries Steam's unlimited total, so a list truncated by `count` stays distinguishable from a complete one ([#36](https://github.com/fkrzski/php-steam-api-sdk/issues/36)).
 - `GetSteamLevelRequest` (`IPlayerService`) returning the player's Steam community level as a plain `int`. Level `0` is also what Steam answers for a SteamID64 that belongs to no account, so it is not treated as a failure ([#37](https://github.com/fkrzski/php-steam-api-sdk/issues/37)).
 - Testing guidance in the docs: faking the connector with Saloon's `MockClient`, and clearing the `MemoryStore` daily counter between tests.

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -21,6 +21,7 @@ tells you which part of the Web API you are talking to:
 
 - src/Http/Requests
   - IPlayerService
+    - GetBadgesRequest.php
     - GetOwnedGamesRequest.php
     - GetRecentlyPlayedGamesRequest.php
     - GetSteamLevelRequest.php
@@ -38,6 +39,7 @@ tells you which part of the Web API you are talking to:
 
 | Request | Returns |
 | --- | --- |
+| [`GetBadgesRequest`](#getbadgesrequest) | `PlayerBadges` |
 | [`GetFriendListRequest`](#getfriendlistrequest) | `list<Friend>` |
 | [`GetOwnedGamesRequest`](#getownedgamesrequest) | `list<OwnedGame>` |
 | [`GetPlayerAchievementsRequest`](#getplayerachievementsrequest) | `PlayerAchievements` |
@@ -48,6 +50,40 @@ tells you which part of the Web API you are talking to:
 | [`GetUserGroupListRequest`](#getusergrouplistrequest) | `list<UserGroup>` |
 | [`GetUserStatsForGameRequest`](#getuserstatsforgamerequest) | `UserStats` |
 | [`ResolveVanityUrlRequest`](#resolvevanityurlrequest) | `SteamId` |
+
+## GetBadgesRequest
+
+```text frame="none"
+new GetBadgesRequest(SteamId $steamId)
+```
+
+<p><Badge text="IPlayerService" variant="note" size="small" />{' '}<Badge text="throws ProfileNotPublicException" variant="danger" size="small" /></p>
+
+Every badge a player has earned, plus the experience behind their community level.
+Badges that come from trading cards name the app they belong to; the rest — event and
+milestone badges — leave `appId` null, which is what separates the two kinds.
+
+```php
+use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetBadgesRequest;
+
+$badges = $connector->send(new GetBadgesRequest($steamId))->dto();
+
+echo $badges->playerLevel, ' — ', $badges->xpNeededToLevelUp, ' XP to go', PHP_EOL;
+
+foreach ($badges->badges as $badge) {
+    echo $badge->badgeId, ' level ', $badge->level, PHP_EOL;
+}
+```
+
+`badgeId` is not unique on its own: trading card badges repeat the same ID across
+different apps and are told apart by `appId`, so the result stays a list rather than a map.
+
+<Aside type="caution" title="An account with no badges answers like one that does not exist">
+A brand-new account and a SteamID64 belonging to nobody both come back as level `0` with
+no badges at all, byte for byte. Neither is treated as a failure, and the SDK does not
+guess between them. The exception is reserved for the empty payload Steam sends for a
+profile it withholds.
+</Aside>
 
 ## GetFriendListRequest
 

--- a/docs/dto-reference.mdx
+++ b/docs/dto-reference.mdx
@@ -53,6 +53,36 @@ Each `PlayerAchievement` carries:
 | `name` | `?string` | Display name (needs `language`). |
 | `description` | `?string` | Description (needs `language`). |
 
+## PlayerBadges
+
+Returned by [`GetBadgesRequest`](/php-steam-api-sdk/api-reference#getbadgesrequest).
+
+| Property | Type | Notes |
+| --- | --- | --- |
+| `badges` | `list<Badge>` | Every badge the account has earned. |
+| `playerXp` | `int` | Total experience on the account. |
+| `playerLevel` | `int` | Steam community level. |
+| `xpNeededToLevelUp` | `int` | Experience still missing for the next level. |
+| `xpNeededForCurrentLevel` | `int` | Experience the current level started at. |
+
+Each `Badge` carries:
+
+| Property | Type | Notes |
+| --- | --- | --- |
+| `badgeId` | `int` | Steam's badge ID, unique only together with `appId`. |
+| `appId` | `?int` | App the badge belongs to, `null` outside trading cards. |
+| `level` | `int` | Badge level. |
+| `completedAt` | `DateTimeImmutable` | When the badge was earned. |
+| `xp` | `int` | Experience the badge contributes to `playerXp`. |
+| `communityItemId` | `?string` | Community item ID, `null` outside trading cards. |
+| `borderColor` | `?int` | Steam's border code, `null` outside trading cards. |
+| `scarcity` | `int` | How many accounts hold this badge. |
+
+<Aside type="note" title="communityItemId stays a string">
+Steam sends it as a string and the values run past what a 32-bit `int` holds, so the SDK
+keeps the wire type instead of casting.
+</Aside>
+
 ## PlayerBan
 
 Returned by [`GetPlayerBansRequest`](/php-steam-api-sdk/api-reference#getplayerbansrequest).

--- a/docs/guide.mdx
+++ b/docs/guide.mdx
@@ -168,7 +168,9 @@ Steam signals failure in two different ways, and the SDK reads both:
 
 Steam overloads `400` across unrelated causes. Key errors are the one case it answers
 with HTML rather than JSON — that is what keeps a misconfigured key from surfacing as a
-data problem.
+data problem. Which status a key error lands on is Steam's choice, not the SDK's:
+`ISteamUser` reports an absent key as `400`, while `IPlayerService` answers `403` for an
+absent key exactly as it does for a rejected one, so there it surfaces as rejected.
 
 <Aside type="caution" title="Two endpoints answer ambiguously">
 `GetPlayerAchievements` returns a byte-identical `Requested app has no stats` body for an

--- a/src/Dto/Badge.php
+++ b/src/Dto/Badge.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Dto;
+
+use DateTimeImmutable;
+
+final readonly class Badge
+{
+    public function __construct(
+        public int $badgeId,
+        public ?int $appId,
+        public int $level,
+        public DateTimeImmutable $completedAt,
+        public int $xp,
+        public ?string $communityItemId,
+        public ?int $borderColor,
+        public int $scarcity,
+    ) {}
+
+    /**
+     * @param  array{
+     *     badgeid: int,
+     *     appid?: int,
+     *     level: int,
+     *     completion_time: int,
+     *     xp: int,
+     *     communityitemid?: string,
+     *     border_color?: int,
+     *     scarcity: int,
+     * }  $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        return new self(
+            badgeId: $payload['badgeid'],
+            appId: $payload['appid'] ?? null,
+            level: $payload['level'],
+            completedAt: new DateTimeImmutable('@'.$payload['completion_time']),
+            xp: $payload['xp'],
+            // Steam sends this one as a string; it exceeds what a 32-bit int holds.
+            communityItemId: $payload['communityitemid'] ?? null,
+            borderColor: $payload['border_color'] ?? null,
+            scarcity: $payload['scarcity'],
+        );
+    }
+}

--- a/src/Dto/PlayerBadges.php
+++ b/src/Dto/PlayerBadges.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Dto;
+
+final readonly class PlayerBadges
+{
+    /**
+     * @param  list<Badge>  $badges
+     */
+    public function __construct(
+        public array $badges,
+        public int $playerXp,
+        public int $playerLevel,
+        public int $xpNeededToLevelUp,
+        public int $xpNeededForCurrentLevel,
+    ) {}
+
+    /**
+     * @param  array{
+     *     badges?: list<array{
+     *         badgeid: int,
+     *         appid?: int,
+     *         level: int,
+     *         completion_time: int,
+     *         xp: int,
+     *         communityitemid?: string,
+     *         border_color?: int,
+     *         scarcity: int,
+     *     }>,
+     *     player_xp: int,
+     *     player_level: int,
+     *     player_xp_needed_to_level_up: int,
+     *     player_xp_needed_current_level: int,
+     * }  $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        return new self(
+            badges: array_map(Badge::fromArray(...), $payload['badges'] ?? []),
+            playerXp: $payload['player_xp'],
+            playerLevel: $payload['player_level'],
+            xpNeededToLevelUp: $payload['player_xp_needed_to_level_up'],
+            xpNeededForCurrentLevel: $payload['player_xp_needed_current_level'],
+        );
+    }
+}

--- a/src/Http/Requests/IPlayerService/GetBadgesRequest.php
+++ b/src/Http/Requests/IPlayerService/GetBadgesRequest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Http\Requests\IPlayerService;
+
+use Fkrzski\SteamApiSdk\Dto\PlayerBadges;
+use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Override;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+
+final class GetBadgesRequest extends Request
+{
+    #[Override]
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        public readonly SteamId $steamId,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return '/IPlayerService/GetBadges/v1/';
+    }
+
+    public function createDtoFromResponse(Response $response): PlayerBadges
+    {
+        /**
+         * @var array{response?: array{badges?: list<array{
+         *     badgeid: int,
+         *     appid?: int,
+         *     level: int,
+         *     completion_time: int,
+         *     xp: int,
+         *     communityitemid?: string,
+         *     border_color?: int,
+         *     scarcity: int,
+         * }>, player_xp: int, player_level: int, player_xp_needed_to_level_up: int, player_xp_needed_current_level: int}} $body
+         */
+        $body = $response->json();
+        $responseBody = $body['response'] ?? [];
+
+        // A SteamID64 that belongs to no account still gets the zeroed progress fields,
+        // so only a withheld profile drops them — which makes it the one identifiable cause.
+        if (! array_key_exists('player_level', $responseBody)) {
+            throw ProfileNotPublicException::forSteamId($this->steamId, $response);
+        }
+
+        return PlayerBadges::fromArray($responseBody);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function defaultQuery(): array
+    {
+        return [
+            'steamid' => $this->steamId->value,
+        ];
+    }
+}

--- a/tests/Feature/Http/Requests/IPlayerService/GetBadgesRequestTest.php
+++ b/tests/Feature/Http/Requests/IPlayerService/GetBadgesRequestTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use Fkrzski\SteamApiSdk\Dto\Badge;
+use Fkrzski\SteamApiSdk\Dto\PlayerBadges;
+use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
+use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetBadgesRequest;
+use Fkrzski\SteamApiSdk\SteamConfig;
+use Fkrzski\SteamApiSdk\SteamConnector;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+covers([
+    GetBadgesRequest::class,
+    PlayerBadges::class,
+    Badge::class,
+    ProfileNotPublicException::class,
+]);
+
+function badgesSteamId(): SteamId
+{
+    return SteamId::fromSteamId64('76561198000000000');
+}
+
+function sendBadgesFixture(string $fixture): PlayerBadges
+{
+    $connector = new SteamConnector(new SteamConfig('test-key'));
+    $connector->withMockClient(new MockClient([
+        GetBadgesRequest::class => MockResponse::fixture(
+            sprintf('IPlayerService/GetBadges/%s', $fixture),
+        ),
+    ]));
+
+    /** @var PlayerBadges $dto */
+    $dto = $connector->send(new GetBadgesRequest(badgesSteamId()))->dto();
+
+    return $dto;
+}
+
+test('endpoint targets GetBadges v1', function (): void {
+    $request = new GetBadgesRequest(badgesSteamId());
+
+    expect($request->resolveEndpoint())->toBe('/IPlayerService/GetBadges/v1/');
+});
+
+test('query carries steamid parameter', function (): void {
+    $request = new GetBadgesRequest(badgesSteamId());
+
+    expect($request->query()->all())->toBe(['steamid' => '76561198000000000']);
+});
+
+test('fixture response parses into Badge DTOs alongside the player progress', function (): void {
+    $dto = sendBadgesFixture('default');
+
+    expect($dto)->toBeInstanceOf(PlayerBadges::class)
+        ->and($dto->badges)->toHaveCount(3)
+        ->and($dto->badges[0])->toBeInstanceOf(Badge::class)
+        ->and($dto->badges[0]->badgeId)->toBe(69)
+        ->and($dto->badges[0]->level)->toBe(1)
+        ->and($dto->badges[0]->completedAt->getTimestamp())->toBe(1787222588)
+        ->and($dto->badges[0]->xp)->toBe(50)
+        ->and($dto->badges[0]->scarcity)->toBe(30146528)
+        ->and($dto->playerXp)->toBe(18668)
+        ->and($dto->playerLevel)->toBe(56)
+        ->and($dto->xpNeededToLevelUp)->toBe(532)
+        ->and($dto->xpNeededForCurrentLevel)->toBe(18600);
+});
+
+test('trading card badge exposes the app it belongs to', function (): void {
+    $badge = sendBadgesFixture('default')->badges[2];
+
+    expect($badge->appId)->toBe(730)
+        ->and($badge->communityItemId)->toBe('4779743956')
+        ->and($badge->borderColor)->toBe(0);
+});
+
+test('badge outside a game leaves the trading card fields null', function (): void {
+    $badge = sendBadgesFixture('default')->badges[0];
+
+    expect($badge->appId)->toBeNull()
+        ->and($badge->communityItemId)->toBeNull()
+        ->and($badge->borderColor)->toBeNull();
+});
+
+test('badge worth no experience keeps zero instead of turning into null', function (): void {
+    $badge = sendBadgesFixture('default')->badges[1];
+
+    expect($badge->xp)->toBe(0);
+});
+
+test('account without badges comes back empty instead of throwing', function (): void {
+    $dto = sendBadgesFixture('zero');
+
+    expect($dto->badges)->toBeEmpty()
+        ->and($dto->playerXp)->toBe(0)
+        ->and($dto->playerLevel)->toBe(0)
+        ->and($dto->xpNeededToLevelUp)->toBe(100)
+        ->and($dto->xpNeededForCurrentLevel)->toBe(0);
+});
+
+test('withheld profile throws ProfileNotPublicException', function (): void {
+    sendBadgesFixture('private');
+})->throws(
+    ProfileNotPublicException::class,
+    'Steam profile 76561198000000000 is not public.',
+);

--- a/tests/Fixtures/Saloon/IPlayerService/GetBadges/default.json
+++ b/tests/Fixtures/Saloon/IPlayerService/GetBadges/default.json
@@ -1,0 +1,40 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "response": {
+            "badges": [
+                {
+                    "badgeid": 69,
+                    "level": 1,
+                    "completion_time": 1787222588,
+                    "xp": 50,
+                    "scarcity": 30146528
+                },
+                {
+                    "badgeid": 57,
+                    "level": 4,
+                    "completion_time": 1638131598,
+                    "xp": 0,
+                    "scarcity": 1322268
+                },
+                {
+                    "badgeid": 1,
+                    "appid": 730,
+                    "level": 5,
+                    "completion_time": 1497464816,
+                    "xp": 500,
+                    "communityitemid": "4779743956",
+                    "border_color": 0,
+                    "scarcity": 10584777
+                }
+            ],
+            "player_xp": 18668,
+            "player_level": 56,
+            "player_xp_needed_to_level_up": 532,
+            "player_xp_needed_current_level": 18600
+        }
+    }
+}

--- a/tests/Fixtures/Saloon/IPlayerService/GetBadges/private.json
+++ b/tests/Fixtures/Saloon/IPlayerService/GetBadges/private.json
@@ -1,0 +1,9 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "response": {}
+    }
+}

--- a/tests/Fixtures/Saloon/IPlayerService/GetBadges/zero.json
+++ b/tests/Fixtures/Saloon/IPlayerService/GetBadges/zero.json
@@ -1,0 +1,14 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "response": {
+            "player_xp": 0,
+            "player_level": 0,
+            "player_xp_needed_to_level_up": 100,
+            "player_xp_needed_current_level": 0
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `feat`: `GetBadgesRequest` (`IPlayerService`) with the `PlayerBadges` and `Badge` DTOs, covering every earned badge alongside the experience behind the community level, with fixtures for a populated profile, an account without badges and a withheld profile.
- `docs`: the endpoint in `docs/api-reference.mdx`, the DTOs in `docs/dto-reference.mdx` and a CHANGELOG entry under Unreleased.
- `docs`: a note in `docs/guide.mdx` that the `400` row of the status mapping table describes `ISteamUser` only.

## Why

Probing the live endpoint pinned down three behaviours:

- A withheld profile answers `{"response":{}}`, while a SteamID64 belonging to no account answers the zeroed progress fields with no `badges` key. Unlike `GetRecentlyPlayedGames`, the two causes are therefore distinguishable, so the missing `player_level` positively identifies a withheld profile and raises `ProfileNotPublicException::forSteamId()`.
- A brand-new account answers byte for byte like a SteamID64 belonging to nobody. Neither is a failure, so both decode to level `0` with an empty list — the same call the SDK already makes for `GetSteamLevel`.
- `IPlayerService` answers `403` for an absent API key, not the `400` that `ISteamUser` sends, so an absent key surfaces as `InvalidApiKeyException::rejected()`. The connector already maps this correctly and needed no change; only the docs implied otherwise, hence the third commit.

`communityitemid` stays a `string`, because Steam sends it as one and the values run past what a 32-bit `int` holds. `badgeid` is not unique on its own — trading card badges repeat it across apps — so the result is a list rather than a map.

Fluent resources on the connector and `GetCommunityBadgeProgress` are the milestone's remaining work and are out of scope here.

Closes #38
