### PR TITLE
Fluent resources on the connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Fluent resources on the connector: `PlayersResource`, `UsersResource` and `StatsResource`, reached through `$connector->players()`, `->users()` and `->stats()`. Each method sends its request and returns the DTO; the request classes are unchanged and stay the way to reach the `Response` itself or Saloon's `pool()` ([#40](https://github.com/fkrzski/php-steam-api-sdk/issues/40)).
 - `GetBadgesRequest` (`IPlayerService`) with the `PlayerBadges` and `Badge` DTOs, covering every earned badge alongside the experience behind the community level. An account with no badges answers exactly like a SteamID64 that belongs to nobody, so neither is treated as a failure ([#38](https://github.com/fkrzski/php-steam-api-sdk/issues/38)).
 - `GetCommunityBadgeProgressRequest` (`IPlayerService`) with the `CommunityBadgeQuest` DTO, listing the quests behind the Steam community badge and whether each one is done. Steam's `badgeid` filter is not exposed, because every ID other than `0` answers with the same empty payload a withheld profile gets ([#39](https://github.com/fkrzski/php-steam-api-sdk/issues/39)).
 - `GetRecentlyPlayedGamesRequest` (`IPlayerService`) with the `RecentlyPlayedGames` and `RecentlyPlayedGame` DTOs and an optional `count` limit. `RecentlyPlayedGames::$totalCount` carries Steam's unlimited total, so a list truncated by `count` stays distinguishable from a complete one ([#36](https://github.com/fkrzski/php-steam-api-sdk/issues/36)).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 Framework-agnostic PHP SDK for the [Steam Web API](https://steamcommunity.com/dev), built on top of [Saloon](https://docs.saloon.dev/) v4.
 
+- Fluent resources on the connector — `$connector->players()->ownedGames($id)`.
 - Strong types (PHP 8.5, PHPStan max, 100% type coverage).
 - Readonly DTOs with `DateTimeImmutable` instead of framework date objects.
 - Domain exception hierarchy rooted at `SteamApiException`.
@@ -29,16 +30,13 @@ composer require fkrzski/php-steam-api-sdk
 ## Quickstart
 
 ```php
-use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetPlayerSummariesRequest;
 use Fkrzski\SteamApiSdk\SteamConfig;
 use Fkrzski\SteamApiSdk\SteamConnector;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 
 $connector = new SteamConnector(new SteamConfig(apiKey: 'YOUR_STEAM_API_KEY'));
 
-$summaries = $connector
-    ->send(new GetPlayerSummariesRequest([SteamId::fromSteamId64('76561198000000000')]))
-    ->dto();
+$summaries = $connector->users()->summaries([SteamId::fromSteamId64('76561198000000000')]);
 
 echo $summaries[0]->personaName;
 ```

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -1,12 +1,13 @@
 ---
 title: API reference
-description: Every request the SDK ships — constructor signature, query parameters, the readonly DTO it returns, and the exceptions each one can throw.
+description: Every endpoint the SDK ships — the resource method, the request class behind it, the readonly DTO it returns, and the exceptions each one throws.
 ---
 
 import { Aside, Badge, FileTree } from '@astrojs/starlight/components';
 
-Each request is a Saloon `Request`; send it with `$connector->send($request)` and
-call `->dto()` on the response. Every argument that identifies a user is a
+Every endpoint has two entry points: a resource method on the connector, which sends and
+returns the DTO, and the request class behind it, which you send yourself. Both take the
+same arguments. Every argument that identifies a user is a
 [`SteamId`](/php-steam-api-sdk/guide#the-steamid-value-object); the shapes coming back are
 documented in [Data objects](/php-steam-api-sdk/dto-reference).
 
@@ -14,49 +15,56 @@ Badges list what a request throws on its own. On top of that, any request can ra
 `InvalidApiKeyException`, `SteamRateLimitException` or `SteamApiException` from the
 connector — see [Exceptions](/php-steam-api-sdk/guide#exceptions).
 
-Requests are namespaced by the Steam interface they belong to, so the `use` statement
-tells you which part of the Web API you are talking to:
+Both layers are namespaced by the Steam interface they belong to — one resource per
+interface, and one request class per endpoint:
 
 <FileTree>
 
-- src/Http/Requests
-  - IPlayerService
-    - GetBadgesRequest.php
-    - GetCommunityBadgeProgressRequest.php
-    - GetOwnedGamesRequest.php
-    - GetRecentlyPlayedGamesRequest.php
-    - GetSteamLevelRequest.php
-  - ISteamUser
-    - GetFriendListRequest.php
-    - GetPlayerBansRequest.php
-    - GetPlayerSummariesRequest.php
-    - GetUserGroupListRequest.php
-    - ResolveVanityUrlRequest.php
-  - ISteamUserStats
-    - GetPlayerAchievementsRequest.php
-    - GetUserStatsForGameRequest.php
+- src/Http
+  - Requests
+    - IPlayerService
+      - GetBadgesRequest.php
+      - GetCommunityBadgeProgressRequest.php
+      - GetOwnedGamesRequest.php
+      - GetRecentlyPlayedGamesRequest.php
+      - GetSteamLevelRequest.php
+    - ISteamUser
+      - GetFriendListRequest.php
+      - GetPlayerBansRequest.php
+      - GetPlayerSummariesRequest.php
+      - GetUserGroupListRequest.php
+      - ResolveVanityUrlRequest.php
+    - ISteamUserStats
+      - GetPlayerAchievementsRequest.php
+      - GetUserStatsForGameRequest.php
+  - Resources
+    - PlayersResource.php
+    - StatsResource.php
+    - UsersResource.php
 
 </FileTree>
 
-| Request | Returns |
-| --- | --- |
-| [`GetBadgesRequest`](#getbadgesrequest) | `PlayerBadges` |
-| [`GetCommunityBadgeProgressRequest`](#getcommunitybadgeprogressrequest) | `list<CommunityBadgeQuest>` |
-| [`GetFriendListRequest`](#getfriendlistrequest) | `list<Friend>` |
-| [`GetOwnedGamesRequest`](#getownedgamesrequest) | `list<OwnedGame>` |
-| [`GetPlayerAchievementsRequest`](#getplayerachievementsrequest) | `PlayerAchievements` |
-| [`GetPlayerBansRequest`](#getplayerbansrequest) | `list<PlayerBan>` |
-| [`GetPlayerSummariesRequest`](#getplayersummariesrequest) | `list<PlayerSummary>` |
-| [`GetRecentlyPlayedGamesRequest`](#getrecentlyplayedgamesrequest) | `RecentlyPlayedGames` |
-| [`GetSteamLevelRequest`](#getsteamlevelrequest) | `int` |
-| [`GetUserGroupListRequest`](#getusergrouplistrequest) | `list<UserGroup>` |
-| [`GetUserStatsForGameRequest`](#getuserstatsforgamerequest) | `UserStats` |
-| [`ResolveVanityUrlRequest`](#resolvevanityurlrequest) | `SteamId` |
+| Request | Resource method | Returns |
+| --- | --- | --- |
+| [`GetBadgesRequest`](#getbadgesrequest) | `players()->badges()` | `PlayerBadges` |
+| [`GetCommunityBadgeProgressRequest`](#getcommunitybadgeprogressrequest) | `players()->communityBadgeProgress()` | `list<CommunityBadgeQuest>` |
+| [`GetFriendListRequest`](#getfriendlistrequest) | `users()->friends()` | `list<Friend>` |
+| [`GetOwnedGamesRequest`](#getownedgamesrequest) | `players()->ownedGames()` | `list<OwnedGame>` |
+| [`GetPlayerAchievementsRequest`](#getplayerachievementsrequest) | `stats()->achievements()` | `PlayerAchievements` |
+| [`GetPlayerBansRequest`](#getplayerbansrequest) | `users()->bans()` | `list<PlayerBan>` |
+| [`GetPlayerSummariesRequest`](#getplayersummariesrequest) | `users()->summaries()` | `list<PlayerSummary>` |
+| [`GetRecentlyPlayedGamesRequest`](#getrecentlyplayedgamesrequest) | `players()->recentlyPlayedGames()` | `RecentlyPlayedGames` |
+| [`GetSteamLevelRequest`](#getsteamlevelrequest) | `players()->steamLevel()` | `int` |
+| [`GetUserGroupListRequest`](#getusergrouplistrequest) | `users()->groups()` | `list<UserGroup>` |
+| [`GetUserStatsForGameRequest`](#getuserstatsforgamerequest) | `stats()->userStats()` | `UserStats` |
+| [`ResolveVanityUrlRequest`](#resolvevanityurlrequest) | `users()->resolveVanityUrl()` | `SteamId` |
 
 ## GetBadgesRequest
 
 ```text frame="none"
-new GetBadgesRequest(SteamId $steamId)
+$connector->players()->badges(SteamId $steamId)
+
+new GetBadgesRequest($steamId)
 ```
 
 <p><Badge text="IPlayerService" variant="note" size="small" />{' '}<Badge text="throws ProfileNotPublicException" variant="danger" size="small" /></p>
@@ -66,9 +74,7 @@ Badges that come from trading cards name the app they belong to; the rest — ev
 milestone badges — leave `appId` null, which is what separates the two kinds.
 
 ```php
-use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetBadgesRequest;
-
-$badges = $connector->send(new GetBadgesRequest($steamId))->dto();
+$badges = $connector->players()->badges($steamId);
 
 echo $badges->playerLevel, ' — ', $badges->xpNeededToLevelUp, ' XP to go', PHP_EOL;
 
@@ -90,7 +96,9 @@ profile it withholds.
 ## GetCommunityBadgeProgressRequest
 
 ```text frame="none"
-new GetCommunityBadgeProgressRequest(SteamId $steamId)
+$connector->players()->communityBadgeProgress(SteamId $steamId)
+
+new GetCommunityBadgeProgressRequest($steamId)
 ```
 
 <p><Badge text="IPlayerService" variant="note" size="small" />{' '}<Badge text="throws ProfileNotPublicException" variant="danger" size="small" /></p>
@@ -100,9 +108,7 @@ account finished it. Steam publishes no schema mapping `questId` to a name, so t
 stay opaque.
 
 ```php
-use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetCommunityBadgeProgressRequest;
-
-$quests = $connector->send(new GetCommunityBadgeProgressRequest($steamId))->dto();
+$quests = $connector->players()->communityBadgeProgress($steamId);
 
 foreach ($quests as $quest) {
     echo $quest->questId, $quest->completed ? ' — done' : ' — pending', PHP_EOL;
@@ -117,7 +123,9 @@ that raises the exception.
 ## GetFriendListRequest
 
 ```text frame="none"
-new GetFriendListRequest(SteamId $steamId, ?FriendRelationship $relationship = null)
+$connector->users()->friends(SteamId $steamId, ?FriendRelationship $relationship = null)
+
+new GetFriendListRequest($steamId, $relationship)
 ```
 
 <p><Badge text="ISteamUser" variant="note" size="small" />{' '}<Badge text="throws ProfileNotPublicException" variant="danger" size="small" /></p>
@@ -127,22 +135,21 @@ relationships. A private friend list is refused with a `401`, not an empty paylo
 
 ```php
 use Fkrzski\SteamApiSdk\Enums\FriendRelationship;
-use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetFriendListRequest;
 
-$friends = $connector
-    ->send(new GetFriendListRequest($steamId, FriendRelationship::Friend))
-    ->dto();
+$friends = $connector->users()->friends($steamId, FriendRelationship::Friend);
 ```
 
 ## GetOwnedGamesRequest
 
 ```text frame="none"
-new GetOwnedGamesRequest(
+$connector->players()->ownedGames(
     SteamId $steamId,
     list<int> $appIdsFilter = [],
     bool $includeAppInfo = false,
     bool $includePlayedFreeGames = false,
 )
+
+new GetOwnedGamesRequest($steamId, $appIdsFilter, $includeAppInfo, $includePlayedFreeGames)
 ```
 
 <p><Badge text="IPlayerService" variant="note" size="small" />{' '}<Badge text="throws ProfileNotPublicException" variant="danger" size="small" /></p>
@@ -152,13 +159,11 @@ The games a player owns. `appIdsFilter` narrows the result to specific app IDs;
 the player has launched.
 
 ```php "includeAppInfo: true"
-use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetOwnedGamesRequest;
-
-$library = $connector->send(new GetOwnedGamesRequest(
+$library = $connector->players()->ownedGames(
     steamId: $steamId,
     appIdsFilter: [381210],
     includeAppInfo: true,
-))->dto();
+);
 ```
 
 <Aside type="caution" title="name and imgIconUrl are opt-in">
@@ -169,7 +174,9 @@ Without `includeAppInfo: true` both properties on every
 ## GetPlayerAchievementsRequest
 
 ```text frame="none"
-new GetPlayerAchievementsRequest(SteamId $steamId, int $appId, ?string $language = null)
+$connector->stats()->achievements(SteamId $steamId, int $appId, ?string $language = null)
+
+new GetPlayerAchievementsRequest($steamId, $appId, $language)
 ```
 
 <p><Badge text="ISteamUserStats" variant="note" size="small" />{' '}<Badge text="throws StatsUnavailableException" variant="danger" size="small" /></p>
@@ -179,13 +186,11 @@ exception covers two causes — no achievements on the app, or a hidden profile 
 Steam reports them identically.
 
 ```php "language: 'english'"
-use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetPlayerAchievementsRequest;
-
-$result = $connector->send(new GetPlayerAchievementsRequest(
+$result = $connector->stats()->achievements(
     steamId: $steamId,
     appId: 381210,
     language: 'english',
-))->dto();
+);
 
 foreach ($result->achievements as $achievement) {
     echo $achievement->apiName, ' — ', $achievement->achieved ? 'unlocked' : 'locked', PHP_EOL;
@@ -201,7 +206,9 @@ ask for a language. `apiName` and `achieved` are always populated.
 ## GetPlayerBansRequest
 
 ```text frame="none"
-new GetPlayerBansRequest(list<SteamId> $steamIds)
+$connector->users()->bans(list<SteamId> $steamIds)
+
+new GetPlayerBansRequest($steamIds)
 ```
 
 <p><Badge text="ISteamUser" variant="note" size="small" />{' '}<Badge text="throws InvalidArgumentException" variant="danger" size="small" />{' '}<Badge text="throws TooManySteamIdsException" variant="danger" size="small" /></p>
@@ -210,9 +217,7 @@ VAC, game, community and economy ban status for **1 to 100** players. Unlike the
 batch endpoint this one needs no public profile — bans come back for private profiles too.
 
 ```php
-use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetPlayerBansRequest;
-
-$bans = $connector->send(new GetPlayerBansRequest([$steamId]))->dto();
+$bans = $connector->users()->bans([$steamId]);
 
 foreach ($bans as $ban) {
     echo $ban->steamId, ' — VAC bans: ', $ban->numberOfVacBans, PHP_EOL;
@@ -222,7 +227,9 @@ foreach ($bans as $ban) {
 ## GetPlayerSummariesRequest
 
 ```text frame="none"
-new GetPlayerSummariesRequest(list<SteamId> $steamIds)
+$connector->users()->summaries(list<SteamId> $steamIds)
+
+new GetPlayerSummariesRequest($steamIds)
 ```
 
 <p><Badge text="ISteamUser" variant="note" size="small" />{' '}<Badge text="throws InvalidArgumentException" variant="danger" size="small" />{' '}<Badge text="throws TooManySteamIdsException" variant="danger" size="small" /></p>
@@ -231,9 +238,7 @@ Public profile summaries for **1 to 100** players. Both limits are checked in th
 constructor, so a bad batch costs no quota.
 
 ```php
-use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetPlayerSummariesRequest;
-
-$summaries = $connector->send(new GetPlayerSummariesRequest([$steamId]))->dto();
+$summaries = $connector->users()->summaries([$steamId]);
 
 foreach ($summaries as $summary) {
     echo $summary->personaName, ' — ', $summary->profileUrl, PHP_EOL;
@@ -243,7 +248,9 @@ foreach ($summaries as $summary) {
 ## GetRecentlyPlayedGamesRequest
 
 ```text frame="none"
-new GetRecentlyPlayedGamesRequest(SteamId $steamId, ?int $count = null)
+$connector->players()->recentlyPlayedGames(SteamId $steamId, ?int $count = null)
+
+new GetRecentlyPlayedGamesRequest($steamId, $count)
 ```
 
 <p><Badge text="IPlayerService" variant="note" size="small" />{' '}<Badge text="throws ProfileNotPublicException" variant="danger" size="small" /></p>
@@ -253,12 +260,7 @@ while `totalCount` on the result stays the full figure — that is how you tell 
 list from a complete one.
 
 ```php "count: 2"
-use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetRecentlyPlayedGamesRequest;
-
-$recent = $connector->send(new GetRecentlyPlayedGamesRequest(
-    steamId: $steamId,
-    count: 2,
-))->dto();
+$recent = $connector->players()->recentlyPlayedGames(steamId: $steamId, count: 2);
 
 foreach ($recent->games as $game) {
     echo $game->name, ' — ', $game->playtimeTwoWeeks, ' min', PHP_EOL;
@@ -274,7 +276,9 @@ hidden profile and for a SteamID64 that belongs to no account.
 ## GetSteamLevelRequest
 
 ```text frame="none"
-new GetSteamLevelRequest(SteamId $steamId)
+$connector->players()->steamLevel(SteamId $steamId)
+
+new GetSteamLevelRequest($steamId)
 ```
 
 <p><Badge text="IPlayerService" variant="note" size="small" />{' '}<Badge text="throws ProfileNotPublicException" variant="danger" size="small" /></p>
@@ -284,9 +288,7 @@ details leaves it readable — only a profile Steam withholds altogether comes b
 and that is what raises the exception.
 
 ```php
-use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetSteamLevelRequest;
-
-$level = $connector->send(new GetSteamLevelRequest($steamId))->dto();
+$level = $connector->players()->steamLevel($steamId);
 ```
 
 <Aside type="caution" title="Level 0 also answers for an account that does not exist">
@@ -297,7 +299,9 @@ brand-new one. Nothing in the payload separates the two, so neither does the SDK
 ## GetUserGroupListRequest
 
 ```text frame="none"
-new GetUserGroupListRequest(SteamId $steamId)
+$connector->users()->groups(SteamId $steamId)
+
+new GetUserGroupListRequest($steamId)
 ```
 
 <p><Badge text="ISteamUser" variant="note" size="small" />{' '}<Badge text="throws ProfileNotPublicException" variant="danger" size="small" /></p>
@@ -306,9 +310,7 @@ The Steam groups a player belongs to. Only group IDs come back — Steam exposes
 group metadata on this endpoint.
 
 ```php
-use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetUserGroupListRequest;
-
-$groups = $connector->send(new GetUserGroupListRequest($steamId))->dto();
+$groups = $connector->users()->groups($steamId);
 
 foreach ($groups as $group) {
     echo $group->gid, PHP_EOL;
@@ -318,7 +320,9 @@ foreach ($groups as $group) {
 ## GetUserStatsForGameRequest
 
 ```text frame="none"
-new GetUserStatsForGameRequest(SteamId $steamId, int $appId, ?string $language = null)
+$connector->stats()->userStats(SteamId $steamId, int $appId, ?string $language = null)
+
+new GetUserStatsForGameRequest($steamId, $appId, $language)
 ```
 
 <p><Badge text="ISteamUserStats" variant="note" size="small" />{' '}<Badge text="throws ProfileNotPublicException" variant="danger" size="small" /></p>
@@ -327,11 +331,7 @@ A player's stats and achievement flags for one game. `language` localises achiev
 metadata (e.g. `'english'`).
 
 ```php
-use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetUserStatsForGameRequest;
-
-$stats = $connector
-    ->send(new GetUserStatsForGameRequest(steamId: $steamId, appId: 381210))
-    ->dto();
+$stats = $connector->stats()->userStats(steamId: $steamId, appId: 381210);
 
 foreach ($stats->stats as $stat) {
     echo $stat->name, ' = ', $stat->value, PHP_EOL;
@@ -341,7 +341,9 @@ foreach ($stats->stats as $stat) {
 ## ResolveVanityUrlRequest
 
 ```text frame="none"
-new ResolveVanityUrlRequest(string $vanityName)
+$connector->users()->resolveVanityUrl(string $vanityName)
+
+new ResolveVanityUrlRequest($vanityName)
 ```
 
 <p><Badge text="ISteamUser" variant="note" size="small" />{' '}<Badge text="throws SteamUserNotFoundException" variant="danger" size="small" /></p>
@@ -351,7 +353,5 @@ Resolves a vanity slug — the `<name>` in `steamcommunity.com/id/<name>` — to
 [`SteamId::extractVanityName()`](/php-steam-api-sdk/guide#the-steamid-value-object) first.
 
 ```php
-use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\ResolveVanityUrlRequest;
-
-$steamId = $connector->send(new ResolveVanityUrlRequest('gabelogannewell'))->dto();
+$steamId = $connector->users()->resolveVanityUrl('gabelogannewell');
 ```

--- a/docs/guide.mdx
+++ b/docs/guide.mdx
@@ -1,13 +1,13 @@
 ---
 title: Guide
-description: The core building blocks — the SteamId value object, how requests turn into readonly DTOs, the exception hierarchy every SDK failure shares, and testing.
+description: The core building blocks — the SteamId value object, the resources that return readonly DTOs, the exception hierarchy every failure shares, and testing.
 ---
 
 import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
 
 Once you have a [configured connector](/php-steam-api-sdk/configuration), three concepts carry the
-rest: the **`SteamId`** value object every request accepts, the **requests** you
-send, and the readonly **DTOs** you get back.
+rest: the **`SteamId`** value object every request accepts, the **resources** you call on
+the connector, and the readonly **DTOs** you get back.
 
 ## The `SteamId` value object
 
@@ -33,13 +33,12 @@ constructor you reach for depends on where the ID came from:
   </TabItem>
   <TabItem label="Vanity URL">
     ```php
-    use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\ResolveVanityUrlRequest;
     use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 
     // A /id/<name> URL carries no Steam ID — pull the slug out and let Steam resolve it.
     $vanity = SteamId::extractVanityName('https://steamcommunity.com/id/gabelogannewell/');
 
-    $id = $connector->send(new ResolveVanityUrlRequest($vanity))->dto();
+    $id = $connector->users()->resolveVanityUrl($vanity);
     ```
   </TabItem>
 </Tabs>
@@ -60,23 +59,30 @@ object. Decoding is not symmetric — rebuild it with `SteamId::fromSteamId64()`
 
 ## Sending requests
 
-Every request is a plain Saloon `Request`. Send it through the connector and call
-`->dto()` to decode the response into typed objects:
+The connector groups every endpoint into a resource per Steam interface — `players()` for
+`IPlayerService`, `users()` for `ISteamUser`, `stats()` for `ISteamUserStats`. Each method
+sends the request and hands back the DTO, so nothing needs importing:
+
+```php
+$summaries = $connector->users()->summaries([$id]);
+```
+
+Behind every resource method sits a plain Saloon `Request`, still public and unchanged.
+Build one yourself when you want the response rather than only the DTO, or a Saloon
+feature that takes a request — `pool()`, `sendAsync()`, `sendAndRetry()`:
 
 ```php
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetPlayerSummariesRequest;
 
-$summaries = $connector
-    ->send(new GetPlayerSummariesRequest([$id]))
-    ->dto();
+$response = $connector->send(new GetPlayerSummariesRequest([$id]));
+
+$response->status();      // 200
+$summaries = $response->dto();
 ```
 
-The connector uses Saloon's `AlwaysThrowOnErrors`, so a non-2xx response fails before
-`->dto()` runs — always as an SDK exception, never a Saloon one. Which request returns
-which DTO is in the [API reference](/php-steam-api-sdk/api-reference).
-
-`->dto()` is a convenience, not a wall: the same `Saloon\Http\Response` still exposes
-`->status()`, `->json()` and `->body()`.
+The connector uses Saloon's `AlwaysThrowOnErrors`, so a non-2xx response fails before the
+DTO is built — always as an SDK exception, never a Saloon one. Which call returns which
+DTO is in the [API reference](/php-steam-api-sdk/api-reference).
 
 ## Exceptions
 
@@ -101,7 +107,7 @@ Catch the leaf you care about, or the root to handle every SDK failure uniformly
     use Fkrzski\SteamApiSdk\Exceptions\SteamApiException;
 
     try {
-        $summaries = $connector->send(new GetPlayerSummariesRequest([$id]))->dto();
+        $summaries = $connector->users()->summaries([$id]);
     } catch (SteamApiException $e) {
         // Every SDK failure lands here — auth, privacy, quota, transport.
         $logger->error($e->getMessage(), ['status' => $e->getCode()]);
@@ -114,10 +120,9 @@ Catch the leaf you care about, or the root to handle every SDK failure uniformly
     ```php
     use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
     use Fkrzski\SteamApiSdk\Exceptions\SteamRateLimitException;
-    use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetOwnedGamesRequest;
 
     try {
-        $library = $connector->send(new GetOwnedGamesRequest($id))->dto();
+        $library = $connector->players()->ownedGames($id);
     } catch (ProfileNotPublicException) {
         $library = [];  // expected — a hidden library is not an error worth logging
     } catch (SteamRateLimitException $e) {
@@ -140,7 +145,7 @@ their code is the HTTP status:
 use Fkrzski\SteamApiSdk\Exceptions\SteamApiException;
 
 try {
-    $summaries = $connector->send(new GetPlayerSummariesRequest([$id]))->dto();
+    $summaries = $connector->users()->summaries([$id]);
 } catch (SteamApiException $e) {
     $e->getCode();          // 403
     $e->response?->body();  // raw Steam payload, or null for client-side failures
@@ -183,7 +188,8 @@ SteamID64 that belongs to no account. Every message names every cause rather tha
 ## Testing
 
 The connector is stock Saloon, so `MockClient` fakes it with no SDK-specific helper.
-`->dto()` still runs against the fake, so assertions are against real DTOs:
+Mocks stay keyed by request class even when the call goes through a resource, and DTOs are
+built from the fake, so assertions run against real DTOs:
 
 <Tabs syncKey="php-test-runner">
   <TabItem label="Pest">
@@ -202,7 +208,7 @@ The connector is stock Saloon, so `MockClient` fakes it with no SDK-specific hel
         $connector = new SteamConnector(new SteamConfig('test-key'));
         $connector->withMockClient($mock);
 
-        $summaries = $connector->send(new GetPlayerSummariesRequest([$id]))->dto();
+        $summaries = $connector->users()->summaries([$id]);
 
         expect($summaries[0]->personaName)->toBe('gabelogannewell');
     });
@@ -227,7 +233,7 @@ The connector is stock Saloon, so `MockClient` fakes it with no SDK-specific hel
             $connector = new SteamConnector(new SteamConfig('test-key'));
             $connector->withMockClient($mock);
 
-            $summaries = $connector->send(new GetPlayerSummariesRequest([$id]))->dto();
+            $summaries = $connector->users()->summaries([$id]);
 
             $this->assertSame('gabelogannewell', $summaries[0]->personaName);
         }

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -15,6 +15,7 @@ fails with a domain exception instead of a silent `null`.
 
 ## Why php-steam-api-sdk
 
+- **Fluent resources** — `$connector->players()->ownedGames($id)`, no request classes to import.
 - **Strongly typed** — PHP 8.5, PHPStan max, 100% type coverage.
 - **Readonly DTOs** — immutable objects with `DateTimeImmutable`, never framework date wrappers.
 - **Domain exceptions** — one hierarchy rooted at `SteamApiException` for every failure.
@@ -65,14 +66,12 @@ through your cache store.
 ## Quickstart
 
 ```php
-use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetPlayerSummariesRequest;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 
-$summaries = $connector
-    ->send(new GetPlayerSummariesRequest([SteamId::fromSteamId64('76561198000000000')]))
-    ->dto();
+$summaries = $connector->users()->summaries([SteamId::fromSteamId64('76561198000000000')]);
 
 echo $summaries[0]->personaName;
 ```
 
-Call `->dto()` on any Saloon response to get the readonly DTO for that request.
+Every endpoint hangs off a resource named after its Steam interface — `players()`,
+`users()`, `stats()` — and returns the readonly DTO straight away.

--- a/src/Http/Resources/PlayersResource.php
+++ b/src/Http/Resources/PlayersResource.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Http\Resources;
+
+use Fkrzski\SteamApiSdk\Dto\CommunityBadgeQuest;
+use Fkrzski\SteamApiSdk\Dto\OwnedGame;
+use Fkrzski\SteamApiSdk\Dto\PlayerBadges;
+use Fkrzski\SteamApiSdk\Dto\RecentlyPlayedGames;
+use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetBadgesRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetCommunityBadgeProgressRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetOwnedGamesRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetRecentlyPlayedGamesRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetSteamLevelRequest;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Saloon\Http\BaseResource;
+
+final class PlayersResource extends BaseResource
+{
+    /**
+     * @param  list<int>  $appIdsFilter
+     * @return list<OwnedGame>
+     */
+    public function ownedGames(
+        SteamId $steamId,
+        array $appIdsFilter = [],
+        bool $includeAppInfo = false,
+        bool $includePlayedFreeGames = false,
+    ): array {
+        $request = new GetOwnedGamesRequest(
+            $steamId,
+            $appIdsFilter,
+            $includeAppInfo,
+            $includePlayedFreeGames,
+        );
+
+        return $request->createDtoFromResponse($this->connector->send($request));
+    }
+
+    public function recentlyPlayedGames(SteamId $steamId, ?int $count = null): RecentlyPlayedGames
+    {
+        $request = new GetRecentlyPlayedGamesRequest($steamId, $count);
+
+        return $request->createDtoFromResponse($this->connector->send($request));
+    }
+
+    public function steamLevel(SteamId $steamId): int
+    {
+        $request = new GetSteamLevelRequest($steamId);
+
+        return $request->createDtoFromResponse($this->connector->send($request));
+    }
+
+    public function badges(SteamId $steamId): PlayerBadges
+    {
+        $request = new GetBadgesRequest($steamId);
+
+        return $request->createDtoFromResponse($this->connector->send($request));
+    }
+
+    /**
+     * @return list<CommunityBadgeQuest>
+     */
+    public function communityBadgeProgress(SteamId $steamId): array
+    {
+        $request = new GetCommunityBadgeProgressRequest($steamId);
+
+        return $request->createDtoFromResponse($this->connector->send($request));
+    }
+}

--- a/src/Http/Resources/StatsResource.php
+++ b/src/Http/Resources/StatsResource.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Http\Resources;
+
+use Fkrzski\SteamApiSdk\Dto\PlayerAchievements;
+use Fkrzski\SteamApiSdk\Dto\UserStats;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetPlayerAchievementsRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetUserStatsForGameRequest;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Saloon\Http\BaseResource;
+
+final class StatsResource extends BaseResource
+{
+    public function achievements(SteamId $steamId, int $appId, ?string $language = null): PlayerAchievements
+    {
+        $request = new GetPlayerAchievementsRequest($steamId, $appId, $language);
+
+        return $request->createDtoFromResponse($this->connector->send($request));
+    }
+
+    public function userStats(SteamId $steamId, int $appId, ?string $language = null): UserStats
+    {
+        $request = new GetUserStatsForGameRequest($steamId, $appId, $language);
+
+        return $request->createDtoFromResponse($this->connector->send($request));
+    }
+}

--- a/src/Http/Resources/UsersResource.php
+++ b/src/Http/Resources/UsersResource.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Http\Resources;
+
+use Fkrzski\SteamApiSdk\Dto\Friend;
+use Fkrzski\SteamApiSdk\Dto\PlayerBan;
+use Fkrzski\SteamApiSdk\Dto\PlayerSummary;
+use Fkrzski\SteamApiSdk\Dto\UserGroup;
+use Fkrzski\SteamApiSdk\Enums\FriendRelationship;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetFriendListRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetPlayerBansRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetPlayerSummariesRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetUserGroupListRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\ResolveVanityUrlRequest;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Saloon\Http\BaseResource;
+
+final class UsersResource extends BaseResource
+{
+    /**
+     * @param  list<SteamId>  $steamIds
+     * @return list<PlayerSummary>
+     */
+    public function summaries(array $steamIds): array
+    {
+        $request = new GetPlayerSummariesRequest($steamIds);
+
+        return $request->createDtoFromResponse($this->connector->send($request));
+    }
+
+    /**
+     * @param  list<SteamId>  $steamIds
+     * @return list<PlayerBan>
+     */
+    public function bans(array $steamIds): array
+    {
+        $request = new GetPlayerBansRequest($steamIds);
+
+        return $request->createDtoFromResponse($this->connector->send($request));
+    }
+
+    /**
+     * @return list<Friend>
+     */
+    public function friends(SteamId $steamId, ?FriendRelationship $relationship = null): array
+    {
+        $request = new GetFriendListRequest($steamId, $relationship);
+
+        return $request->createDtoFromResponse($this->connector->send($request));
+    }
+
+    /**
+     * @return list<UserGroup>
+     */
+    public function groups(SteamId $steamId): array
+    {
+        $request = new GetUserGroupListRequest($steamId);
+
+        return $request->createDtoFromResponse($this->connector->send($request));
+    }
+
+    public function resolveVanityUrl(string $vanityName): SteamId
+    {
+        $request = new ResolveVanityUrlRequest($vanityName);
+
+        return $request->createDtoFromResponse($this->connector->send($request));
+    }
+}

--- a/src/SteamConnector.php
+++ b/src/SteamConnector.php
@@ -8,6 +8,9 @@ use Fkrzski\SteamApiSdk\Exceptions\InvalidApiKeyException;
 use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
 use Fkrzski\SteamApiSdk\Exceptions\SteamApiException;
 use Fkrzski\SteamApiSdk\Exceptions\SteamRateLimitException;
+use Fkrzski\SteamApiSdk\Http\Resources\PlayersResource;
+use Fkrzski\SteamApiSdk\Http\Resources\StatsResource;
+use Fkrzski\SteamApiSdk\Http\Resources\UsersResource;
 use Override;
 use Saloon\Http\Connector;
 use Saloon\Http\Response;
@@ -30,6 +33,21 @@ class SteamConnector extends Connector
     public function resolveBaseUrl(): string
     {
         return 'https://api.steampowered.com';
+    }
+
+    public function players(): PlayersResource
+    {
+        return new PlayersResource($this);
+    }
+
+    public function users(): UsersResource
+    {
+        return new UsersResource($this);
+    }
+
+    public function stats(): StatsResource
+    {
+        return new StatsResource($this);
     }
 
     /**

--- a/tests/Architecture/ArchitectureTest.php
+++ b/tests/Architecture/ArchitectureTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 use Fkrzski\SteamApiSdk\Exceptions\SteamApiException;
 use Fkrzski\SteamApiSdk\SteamConnector;
+use Saloon\Http\BaseResource;
 use Saloon\Http\Connector;
 use Saloon\Http\Request;
 
@@ -37,6 +38,11 @@ arch('enums are backed enums')
 arch('requests extend the Saloon Request base class')
     ->expect('Fkrzski\SteamApiSdk\Http\Requests')
     ->toExtend(Request::class);
+
+arch('resources extend the Saloon base resource')
+    ->expect('Fkrzski\SteamApiSdk\Http\Resources')
+    ->toExtend(BaseResource::class)
+    ->toBeFinal();
 
 arch('exceptions extend the SDK root exception')
     ->expect('Fkrzski\SteamApiSdk\Exceptions')

--- a/tests/Feature/Http/Resources/PlayersResourceTest.php
+++ b/tests/Feature/Http/Resources/PlayersResourceTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use Fkrzski\SteamApiSdk\Dto\CommunityBadgeQuest;
+use Fkrzski\SteamApiSdk\Dto\OwnedGame;
+use Fkrzski\SteamApiSdk\Dto\PlayerBadges;
+use Fkrzski\SteamApiSdk\Dto\RecentlyPlayedGames;
+use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetBadgesRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetCommunityBadgeProgressRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetOwnedGamesRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetRecentlyPlayedGamesRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\IPlayerService\GetSteamLevelRequest;
+use Fkrzski\SteamApiSdk\Http\Resources\PlayersResource;
+use Fkrzski\SteamApiSdk\SteamConfig;
+use Fkrzski\SteamApiSdk\SteamConnector;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+covers(PlayersResource::class);
+
+function playersResourceSteamId(): SteamId
+{
+    return SteamId::fromSteamId64('76561198000000000');
+}
+
+function playersResourceMock(string $requestClass, string $fixture): MockClient
+{
+    return new MockClient([$requestClass => MockResponse::fixture($fixture)]);
+}
+
+function playersResource(MockClient $mockClient): PlayersResource
+{
+    $connector = new SteamConnector(new SteamConfig('test-key'));
+    $connector->withMockClient($mockClient);
+
+    return $connector->players();
+}
+
+test('ownedGames sends GetOwnedGames and returns OwnedGame DTOs', function (): void {
+    $mockClient = playersResourceMock(GetOwnedGamesRequest::class, 'IPlayerService/GetOwnedGames/default');
+
+    $games = playersResource($mockClient)->ownedGames(playersResourceSteamId());
+
+    expect($games)->toHaveCount(1)
+        ->and($games[0])->toBeInstanceOf(OwnedGame::class)
+        ->and($games[0]->appId)->toBe(381210)
+        ->and($mockClient->getLastRequest())->toBeInstanceOf(GetOwnedGamesRequest::class);
+});
+
+test('ownedGames omits every optional parameter by default', function (): void {
+    $mockClient = playersResourceMock(GetOwnedGamesRequest::class, 'IPlayerService/GetOwnedGames/default');
+
+    playersResource($mockClient)->ownedGames(playersResourceSteamId());
+
+    expect($mockClient->getLastRequest()?->query()->all())->toBe(['steamid' => '76561198000000000']);
+});
+
+test('ownedGames forwards every optional parameter', function (): void {
+    $mockClient = playersResourceMock(GetOwnedGamesRequest::class, 'IPlayerService/GetOwnedGames/default');
+
+    playersResource($mockClient)->ownedGames(playersResourceSteamId(), [381210], true, true);
+
+    expect($mockClient->getLastRequest()?->query()->all())->toBe([
+        'steamid' => '76561198000000000',
+        'appids_filter' => [381210],
+        'include_appinfo' => 1,
+        'include_played_free_games' => 1,
+    ]);
+});
+
+test('recentlyPlayedGames sends GetRecentlyPlayedGames and returns the DTO', function (): void {
+    $mockClient = playersResourceMock(
+        GetRecentlyPlayedGamesRequest::class,
+        'IPlayerService/GetRecentlyPlayedGames/default',
+    );
+
+    $recent = playersResource($mockClient)->recentlyPlayedGames(playersResourceSteamId());
+
+    expect($recent)->toBeInstanceOf(RecentlyPlayedGames::class)
+        ->and($recent->totalCount)->toBe(3)
+        ->and($mockClient->getLastRequest()?->query()->all())->toBe(['steamid' => '76561198000000000']);
+});
+
+test('recentlyPlayedGames forwards the count limit', function (): void {
+    $mockClient = playersResourceMock(
+        GetRecentlyPlayedGamesRequest::class,
+        'IPlayerService/GetRecentlyPlayedGames/limited',
+    );
+
+    playersResource($mockClient)->recentlyPlayedGames(playersResourceSteamId(), 2);
+
+    expect($mockClient->getLastRequest()?->query()->all())->toBe([
+        'steamid' => '76561198000000000',
+        'count' => 2,
+    ]);
+});
+
+test('steamLevel sends GetSteamLevel and returns a plain int', function (): void {
+    $mockClient = playersResourceMock(GetSteamLevelRequest::class, 'IPlayerService/GetSteamLevel/default');
+
+    $level = playersResource($mockClient)->steamLevel(playersResourceSteamId());
+
+    expect($level)->toBe(56)
+        ->and($mockClient->getLastRequest())->toBeInstanceOf(GetSteamLevelRequest::class);
+});
+
+test('badges sends GetBadges and returns the DTO', function (): void {
+    $mockClient = playersResourceMock(GetBadgesRequest::class, 'IPlayerService/GetBadges/default');
+
+    $badges = playersResource($mockClient)->badges(playersResourceSteamId());
+
+    expect($badges)->toBeInstanceOf(PlayerBadges::class)
+        ->and($badges->playerLevel)->toBe(56)
+        ->and($badges->badges)->toHaveCount(3);
+});
+
+test('communityBadgeProgress sends GetCommunityBadgeProgress and returns quest DTOs', function (): void {
+    $mockClient = playersResourceMock(
+        GetCommunityBadgeProgressRequest::class,
+        'IPlayerService/GetCommunityBadgeProgress/default',
+    );
+
+    $quests = playersResource($mockClient)->communityBadgeProgress(playersResourceSteamId());
+
+    expect($quests)->toHaveCount(3)
+        ->and($quests[0])->toBeInstanceOf(CommunityBadgeQuest::class)
+        ->and($quests[0]->questId)->toBe(115);
+});

--- a/tests/Feature/Http/Resources/StatsResourceTest.php
+++ b/tests/Feature/Http/Resources/StatsResourceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use Fkrzski\SteamApiSdk\Dto\PlayerAchievements;
+use Fkrzski\SteamApiSdk\Dto\UserStats;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetPlayerAchievementsRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetUserStatsForGameRequest;
+use Fkrzski\SteamApiSdk\Http\Resources\StatsResource;
+use Fkrzski\SteamApiSdk\SteamConfig;
+use Fkrzski\SteamApiSdk\SteamConnector;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+covers(StatsResource::class);
+
+function statsResourceSteamId(): SteamId
+{
+    return SteamId::fromSteamId64('76561198148125221');
+}
+
+function statsResourceMock(string $requestClass, string $fixture): MockClient
+{
+    return new MockClient([$requestClass => MockResponse::fixture($fixture)]);
+}
+
+function statsResource(MockClient $mockClient): StatsResource
+{
+    $connector = new SteamConnector(new SteamConfig('test-key'));
+    $connector->withMockClient($mockClient);
+
+    return $connector->stats();
+}
+
+test('achievements sends GetPlayerAchievements and returns the DTO', function (): void {
+    $mockClient = statsResourceMock(
+        GetPlayerAchievementsRequest::class,
+        'ISteamUserStats/GetPlayerAchievements/default',
+    );
+
+    $achievements = statsResource($mockClient)->achievements(statsResourceSteamId(), 381210);
+
+    expect($achievements)->toBeInstanceOf(PlayerAchievements::class)
+        ->and($achievements->gameName)->toBe('Dead by Daylight')
+        ->and($achievements->achievements)->toHaveCount(2)
+        ->and($mockClient->getLastRequest()?->query()->all())->toBe([
+            'steamid' => '76561198148125221',
+            'appid' => 381210,
+        ]);
+});
+
+test('achievements forwards the language', function (): void {
+    $mockClient = statsResourceMock(
+        GetPlayerAchievementsRequest::class,
+        'ISteamUserStats/GetPlayerAchievements/localized',
+    );
+
+    statsResource($mockClient)->achievements(statsResourceSteamId(), 381210, 'polish');
+
+    expect($mockClient->getLastRequest()?->query()->all())->toBe([
+        'steamid' => '76561198148125221',
+        'appid' => 381210,
+        'l' => 'polish',
+    ]);
+});
+
+test('userStats sends GetUserStatsForGame and returns the DTO', function (): void {
+    $mockClient = statsResourceMock(
+        GetUserStatsForGameRequest::class,
+        'ISteamUserStats/GetUserStatsForGame/default',
+    );
+
+    $stats = statsResource($mockClient)->userStats(statsResourceSteamId(), 381210);
+
+    expect($stats)->toBeInstanceOf(UserStats::class)
+        ->and($stats->gameName)->toBe('Dead by Daylight')
+        ->and($stats->stats)->toHaveCount(2)
+        ->and($mockClient->getLastRequest()?->query()->all())->toBe([
+            'steamid' => '76561198148125221',
+            'appid' => 381210,
+        ]);
+});
+
+test('userStats forwards the language', function (): void {
+    $mockClient = statsResourceMock(
+        GetUserStatsForGameRequest::class,
+        'ISteamUserStats/GetUserStatsForGame/default',
+    );
+
+    statsResource($mockClient)->userStats(statsResourceSteamId(), 381210, 'polish');
+
+    expect($mockClient->getLastRequest()?->query()->all())->toBe([
+        'steamid' => '76561198148125221',
+        'appid' => 381210,
+        'l' => 'polish',
+    ]);
+});

--- a/tests/Feature/Http/Resources/UsersResourceTest.php
+++ b/tests/Feature/Http/Resources/UsersResourceTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use Fkrzski\SteamApiSdk\Dto\Friend;
+use Fkrzski\SteamApiSdk\Dto\PlayerBan;
+use Fkrzski\SteamApiSdk\Dto\PlayerSummary;
+use Fkrzski\SteamApiSdk\Dto\UserGroup;
+use Fkrzski\SteamApiSdk\Enums\FriendRelationship;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetFriendListRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetPlayerBansRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetPlayerSummariesRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetUserGroupListRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\ResolveVanityUrlRequest;
+use Fkrzski\SteamApiSdk\Http\Resources\UsersResource;
+use Fkrzski\SteamApiSdk\SteamConfig;
+use Fkrzski\SteamApiSdk\SteamConnector;
+use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+covers(UsersResource::class);
+
+function usersResourceSteamId(): SteamId
+{
+    return SteamId::fromSteamId64('76561198000000000');
+}
+
+function usersResourceMock(string $requestClass, string $fixture): MockClient
+{
+    return new MockClient([$requestClass => MockResponse::fixture($fixture)]);
+}
+
+function usersResource(MockClient $mockClient): UsersResource
+{
+    $connector = new SteamConnector(new SteamConfig('test-key'));
+    $connector->withMockClient($mockClient);
+
+    return $connector->users();
+}
+
+test('summaries sends GetPlayerSummaries and returns PlayerSummary DTOs', function (): void {
+    $mockClient = usersResourceMock(GetPlayerSummariesRequest::class, 'ISteamUser/GetPlayerSummaries/default');
+
+    $summaries = usersResource($mockClient)->summaries([usersResourceSteamId()]);
+
+    expect($summaries)->toHaveCount(2)
+        ->and($summaries[0])->toBeInstanceOf(PlayerSummary::class)
+        ->and($summaries[0]->personaName)->toBe('tester-one')
+        ->and($mockClient->getLastRequest()?->query()->all())->toBe(['steamids' => '76561198000000000']);
+});
+
+test('bans sends GetPlayerBans and returns PlayerBan DTOs', function (): void {
+    $mockClient = usersResourceMock(GetPlayerBansRequest::class, 'ISteamUser/GetPlayerBans/default');
+
+    $bans = usersResource($mockClient)->bans([usersResourceSteamId()]);
+
+    expect($bans)->toHaveCount(2)
+        ->and($bans[0])->toBeInstanceOf(PlayerBan::class)
+        ->and($bans[1]->isVacBanned)->toBeTrue()
+        ->and($mockClient->getLastRequest()?->query()->all())->toBe(['steamids' => '76561198000000000']);
+});
+
+test('friends sends GetFriendList and returns Friend DTOs', function (): void {
+    $mockClient = usersResourceMock(GetFriendListRequest::class, 'ISteamUser/GetFriendList/default');
+
+    $friends = usersResource($mockClient)->friends(usersResourceSteamId());
+
+    expect($friends)->toHaveCount(4)
+        ->and($friends[0])->toBeInstanceOf(Friend::class)
+        ->and($friends[0]->steamId->value)->toBe('76561198000408055')
+        ->and($mockClient->getLastRequest()?->query()->all())->toBe(['steamid' => '76561198000000000']);
+});
+
+test('friends forwards the relationship filter', function (): void {
+    $mockClient = usersResourceMock(GetFriendListRequest::class, 'ISteamUser/GetFriendList/default');
+
+    usersResource($mockClient)->friends(usersResourceSteamId(), FriendRelationship::Friend);
+
+    expect($mockClient->getLastRequest()?->query()->all())->toBe([
+        'steamid' => '76561198000000000',
+        'relationship' => 'friend',
+    ]);
+});
+
+test('groups sends GetUserGroupList and returns UserGroup DTOs', function (): void {
+    $mockClient = usersResourceMock(GetUserGroupListRequest::class, 'ISteamUser/GetUserGroupList/default');
+
+    $groups = usersResource($mockClient)->groups(usersResourceSteamId());
+
+    expect($groups)->toHaveCount(4)
+        ->and($groups[0])->toBeInstanceOf(UserGroup::class)
+        ->and($groups[0]->gid)->toBe('4218398');
+});
+
+test('resolveVanityUrl sends ResolveVanityURL and returns a SteamId', function (): void {
+    $mockClient = usersResourceMock(ResolveVanityUrlRequest::class, 'ISteamUser/ResolveVanityUrl/success');
+
+    $steamId = usersResource($mockClient)->resolveVanityUrl('gabelogannewell');
+
+    expect($steamId)->toBeInstanceOf(SteamId::class)
+        ->and($steamId->value)->toBe('76561198000000000')
+        ->and($mockClient->getLastRequest()?->query()->all())->toBe(['vanityurl' => 'gabelogannewell']);
+});

--- a/tests/Feature/SteamConnectorTest.php
+++ b/tests/Feature/SteamConnectorTest.php
@@ -6,6 +6,9 @@ use Fkrzski\SteamApiSdk\Exceptions\InvalidApiKeyException;
 use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
 use Fkrzski\SteamApiSdk\Exceptions\SteamApiException;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetFriendListRequest;
+use Fkrzski\SteamApiSdk\Http\Resources\PlayersResource;
+use Fkrzski\SteamApiSdk\Http\Resources\StatsResource;
+use Fkrzski\SteamApiSdk\Http\Resources\UsersResource;
 use Fkrzski\SteamApiSdk\SteamConfig;
 use Fkrzski\SteamApiSdk\SteamConnector;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
@@ -28,6 +31,14 @@ test('default query carries api key', function (): void {
     $connector = new SteamConnector(new SteamConfig('secret-key'));
 
     expect($connector->query()->all())->toBe(['key' => 'secret-key']);
+});
+
+test('resource accessors expose one resource per Steam interface', function (): void {
+    $connector = new SteamConnector(new SteamConfig('any'));
+
+    expect($connector->players())->toBeInstanceOf(PlayersResource::class)
+        ->and($connector->users())->toBeInstanceOf(UsersResource::class)
+        ->and($connector->stats())->toBeInstanceOf(StatsResource::class);
 });
 
 test('connector uses AlwaysThrowOnErrors plugin', function (): void {


### PR DESCRIPTION
## Summary

- `feat` — `PlayersResource`, `UsersResource` and `StatsResource`, reached through `$connector->players()`, `->users()` and `->stats()`. Each method takes the arguments of the request it wraps, sends it and returns the DTO.
- `docs` — the guide leads with resources and keeps request classes as the escape hatch, the API reference gains a resource-method column and a fluent signature per endpoint, quickstarts in `index.mdx` and the README follow.

Additive only: every request class is public and unchanged.

## Why

Two open questions from the issue, settled:

**Methods send and return the DTO** rather than a configured `Request`. The `MockClient` argument for returning a request does not hold — mocks are keyed by request class and the mock lives on the connector, so `$connector->users()->summaries([$id])` fakes exactly as before. Pooling is real but already served: the request classes stay public, so `pool()`, `sendAsync()`, `sendAndRetry()` and raw `Response` access lose nothing. A twin `requests()` branch is additive and can wait for the pooling helper in 1.0.0.

**Method names drop the noun the resource already supplies** — `users()->summaries()`, `->bans()`, `->friends()`, `->groups()`, `stats()->achievements()`, `->userStats()`. `stats()` rather than `userStats()` for the resource, because `ISteamUserStats` gains non-user endpoints in 0.6.0, and `userStats()`/`globalStats()` stays unambiguous where `forGame()` would not.

The Laravel bridge exposes the same endpoints under a flat facade (`Steam::userGroupList()`), so the two packages now carry two naming schemes. Realigning the bridge is a follow-up there, out of scope here.

Closes #40
