### PR TITLE
Language enum + default in SteamConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `Language` enum backing Steam's `l` query parameter, and a `language` on `SteamConfig` that applies it to every request whose endpoint localises its payload. Steam's codes are Valve's own rather than ISO, so the enum transcribes their table instead of mapping to one ([#46](https://github.com/fkrzski/php-steam-api-sdk/issues/46)).
+
+### Changed
+
+- **BC break.** `$language` is a `?Language` instead of a `?string` on `GetPlayerAchievementsRequest`, `GetUserStatsForGameRequest` and both `StatsResource` methods. Callers passing a raw code swap `'english'` for `Language::English` ([#46](https://github.com/fkrzski/php-steam-api-sdk/issues/46)).
+
 ## [0.5.0] - 2026-08-26
 
 ### Added

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -174,7 +174,7 @@ Without `includeAppInfo: true` both properties on every
 ## GetPlayerAchievementsRequest
 
 ```text frame="none"
-$connector->stats()->achievements(SteamId $steamId, int $appId, ?string $language = null)
+$connector->stats()->achievements(SteamId $steamId, int $appId, ?Language $language = null)
 
 new GetPlayerAchievementsRequest($steamId, $appId, $language)
 ```
@@ -185,11 +185,13 @@ A player's achievements for one game, each with its unlock state and time. The
 exception covers two causes — no achievements on the app, or a hidden profile — because
 Steam reports them identically.
 
-```php "language: 'english'"
+```php "language: Language::English"
+use Fkrzski\SteamApiSdk\Enums\Language;
+
 $result = $connector->stats()->achievements(
     steamId: $steamId,
     appId: 381210,
-    language: 'english',
+    language: Language::English,
 );
 
 foreach ($result->achievements as $achievement) {
@@ -200,7 +202,8 @@ foreach ($result->achievements as $achievement) {
 <Aside type="caution" title="Without a language you get API names only">
 `name` and `description` on every
 [`PlayerAchievement`](/php-steam-api-sdk/dto-reference#playerachievements) stay `null` until you
-ask for a language. `apiName` and `achieved` are always populated.
+ask for a language. `apiName` and `achieved` are always populated. A
+[default on `SteamConfig`](/php-steam-api-sdk/configuration#default-language) counts as asking.
 </Aside>
 
 ## GetPlayerBansRequest
@@ -320,7 +323,7 @@ foreach ($groups as $group) {
 ## GetUserStatsForGameRequest
 
 ```text frame="none"
-$connector->stats()->userStats(SteamId $steamId, int $appId, ?string $language = null)
+$connector->stats()->userStats(SteamId $steamId, int $appId, ?Language $language = null)
 
 new GetUserStatsForGameRequest($steamId, $appId, $language)
 ```
@@ -328,7 +331,7 @@ new GetUserStatsForGameRequest($steamId, $appId, $language)
 <p><Badge text="ISteamUserStats" variant="note" size="small" />{' '}<Badge text="throws ProfileNotPublicException" variant="danger" size="small" /></p>
 
 A player's stats and achievement flags for one game. `language` localises achievement
-metadata (e.g. `'english'`).
+metadata; see the [`Language`](/php-steam-api-sdk/dto-reference#language) enum.
 
 ```php
 $stats = $connector->stats()->userStats(steamId: $steamId, appId: 381210);

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -45,11 +45,37 @@ per call.
 | --- | --- | --- | --- |
 | `apiKey` | `string` | — (required) | Your Steam Web API key. |
 | `rateLimitStore` | `?RateLimitStore` | `MemoryStore` | Where the daily request budget is tracked. |
+| `language` | `?Language` | `null` | Language for endpoints that localise their payload. |
 
 <Aside type="note" title="Readonly, so replace rather than mutate">
 `SteamConfig` is `final readonly` — to change a setting, construct a new config and a
 new connector.
 </Aside>
+
+## Default language
+
+Steam localises achievement names and descriptions through the `l` query parameter. Set it
+once on the config rather than on every call:
+
+```php title="steam.php" "language: Language::Polish"
+use Fkrzski\SteamApiSdk\Enums\Language;
+
+$connector = new SteamConnector(new SteamConfig(
+    apiKey: $_ENV['STEAM_API_KEY'],
+    language: Language::Polish,
+));
+```
+
+A language passed to a call wins over the config, and endpoints that do not localise
+anything never receive one:
+
+```php
+$connector->stats()->achievements($steamId, 381210);                    // polish
+$connector->stats()->achievements($steamId, 381210, Language::English); // english
+```
+
+Steam's codes are Valve's own rather than ISO, so the
+[`Language`](/php-steam-api-sdk/dto-reference#language) enum transcribes their table.
 
 ## Rate limiting
 

--- a/docs/dto-reference.mdx
+++ b/docs/dto-reference.mdx
@@ -192,7 +192,7 @@ has `name` (`string`) and `achieved` (`bool`).
 
 ## Enums
 
-Three of these mirror Steam's wire values; `CommentPermission` and `EconomyBan` do not,
+Four of these mirror Steam's wire values; `CommentPermission` and `EconomyBan` do not,
 and those are the two worth reading before you `match` on them.
 
 ### CommentPermission
@@ -218,6 +218,26 @@ undocumented, so the value set is provably open.
 
 Backed by `string` — `All` (`'all'`), `Friend` (`'friend'`). The values Steam accepts on
 the `relationship` query parameter.
+
+### Language
+
+Backed by `string`, using Steam's codes for the `l` query parameter. They are not ISO
+codes, so five cases are named for the language and backed by Valve's spelling of it:
+
+| Case | Value |
+| --- | --- |
+| `ChineseSimplified` | `'schinese'` |
+| `ChineseTraditional` | `'tchinese'` |
+| `Korean` | `'koreana'` |
+| `PortugueseBrazil` | `'brazilian'` |
+| `SpanishLatinAmerican` | `'latam'` |
+
+The other twenty-five back onto their own name lowercased: `Arabic`, `Bulgarian`, `Czech`,
+`Danish`, `Dutch`, `English`, `Finnish`, `French`, `German`, `Greek`, `Hungarian`,
+`Indonesian`, `Italian`, `Japanese`, `Norwegian`, `Polish`, `Portuguese`, `Romanian`,
+`Russian`, `Spanish`, `Swedish`, `Thai`, `Turkish`, `Ukrainian`, `Vietnamese`.
+
+Set one per call, or [once on `SteamConfig`](/php-steam-api-sdk/configuration#default-language).
 
 ### PersonaState
 

--- a/src/Contracts/HasLanguage.php
+++ b/src/Contracts/HasLanguage.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Contracts;
+
+use Fkrzski\SteamApiSdk\Enums\Language;
+
+/**
+ * Marks a request whose endpoint understands the `l` query parameter, so the connector
+ * knows where the configured default language may be filled in.
+ */
+interface HasLanguage
+{
+    public ?Language $language { get; }
+}

--- a/src/Enums/Language.php
+++ b/src/Enums/Language.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Enums;
+
+/**
+ * Steam's own language codes for the `l` query parameter, not ISO ones — which is why
+ * case names and backing values part ways on Korean, Brazilian Portuguese and the rest.
+ */
+enum Language: string
+{
+    case Arabic = 'arabic';
+    case Bulgarian = 'bulgarian';
+    case ChineseSimplified = 'schinese';
+    case ChineseTraditional = 'tchinese';
+    case Czech = 'czech';
+    case Danish = 'danish';
+    case Dutch = 'dutch';
+    case English = 'english';
+    case Finnish = 'finnish';
+    case French = 'french';
+    case German = 'german';
+    case Greek = 'greek';
+    case Hungarian = 'hungarian';
+    case Indonesian = 'indonesian';
+    case Italian = 'italian';
+    case Japanese = 'japanese';
+    case Korean = 'koreana';
+    case Norwegian = 'norwegian';
+    case Polish = 'polish';
+    case Portuguese = 'portuguese';
+    case PortugueseBrazil = 'brazilian';
+    case Romanian = 'romanian';
+    case Russian = 'russian';
+    case Spanish = 'spanish';
+    case SpanishLatinAmerican = 'latam';
+    case Swedish = 'swedish';
+    case Thai = 'thai';
+    case Turkish = 'turkish';
+    case Ukrainian = 'ukrainian';
+    case Vietnamese = 'vietnamese';
+}

--- a/src/Http/Requests/ISteamUserStats/GetPlayerAchievementsRequest.php
+++ b/src/Http/Requests/ISteamUserStats/GetPlayerAchievementsRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats;
 
 use Fkrzski\SteamApiSdk\Dto\PlayerAchievements;
+use Fkrzski\SteamApiSdk\Enums\Language;
 use Fkrzski\SteamApiSdk\Exceptions\StatsUnavailableException;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 use Override;
@@ -21,7 +22,7 @@ final class GetPlayerAchievementsRequest extends Request
     public function __construct(
         public readonly SteamId $steamId,
         public readonly int $appId,
-        public readonly ?string $language = null,
+        public readonly ?Language $language = null,
     ) {}
 
     public function resolveEndpoint(): string
@@ -69,8 +70,8 @@ final class GetPlayerAchievementsRequest extends Request
             'appid' => $this->appId,
         ];
 
-        if ($this->language !== null) {
-            $query['l'] = $this->language;
+        if ($this->language instanceof Language) {
+            $query['l'] = $this->language->value;
         }
 
         return $query;

--- a/src/Http/Requests/ISteamUserStats/GetPlayerAchievementsRequest.php
+++ b/src/Http/Requests/ISteamUserStats/GetPlayerAchievementsRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats;
 
+use Fkrzski\SteamApiSdk\Contracts\HasLanguage;
 use Fkrzski\SteamApiSdk\Dto\PlayerAchievements;
 use Fkrzski\SteamApiSdk\Enums\Language;
 use Fkrzski\SteamApiSdk\Exceptions\StatsUnavailableException;
@@ -14,7 +15,7 @@ use Saloon\Http\Request;
 use Saloon\Http\Response;
 use Throwable;
 
-final class GetPlayerAchievementsRequest extends Request
+final class GetPlayerAchievementsRequest extends Request implements HasLanguage
 {
     #[Override]
     protected Method $method = Method::GET;

--- a/src/Http/Requests/ISteamUserStats/GetUserStatsForGameRequest.php
+++ b/src/Http/Requests/ISteamUserStats/GetUserStatsForGameRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats;
 
+use Fkrzski\SteamApiSdk\Contracts\HasLanguage;
 use Fkrzski\SteamApiSdk\Dto\UserStats;
 use Fkrzski\SteamApiSdk\Enums\Language;
 use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
@@ -14,7 +15,7 @@ use Saloon\Http\Request;
 use Saloon\Http\Response;
 use Throwable;
 
-final class GetUserStatsForGameRequest extends Request
+final class GetUserStatsForGameRequest extends Request implements HasLanguage
 {
     #[Override]
     protected Method $method = Method::GET;

--- a/src/Http/Requests/ISteamUserStats/GetUserStatsForGameRequest.php
+++ b/src/Http/Requests/ISteamUserStats/GetUserStatsForGameRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats;
 
 use Fkrzski\SteamApiSdk\Dto\UserStats;
+use Fkrzski\SteamApiSdk\Enums\Language;
 use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 use Override;
@@ -21,7 +22,7 @@ final class GetUserStatsForGameRequest extends Request
     public function __construct(
         public readonly SteamId $steamId,
         public readonly int $appId,
-        public readonly ?string $language = null,
+        public readonly ?Language $language = null,
     ) {}
 
     public function resolveEndpoint(): string
@@ -68,8 +69,8 @@ final class GetUserStatsForGameRequest extends Request
             'appid' => $this->appId,
         ];
 
-        if ($this->language !== null) {
-            $query['l'] = $this->language;
+        if ($this->language instanceof Language) {
+            $query['l'] = $this->language->value;
         }
 
         return $query;

--- a/src/Http/Resources/StatsResource.php
+++ b/src/Http/Resources/StatsResource.php
@@ -6,6 +6,7 @@ namespace Fkrzski\SteamApiSdk\Http\Resources;
 
 use Fkrzski\SteamApiSdk\Dto\PlayerAchievements;
 use Fkrzski\SteamApiSdk\Dto\UserStats;
+use Fkrzski\SteamApiSdk\Enums\Language;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetPlayerAchievementsRequest;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetUserStatsForGameRequest;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
@@ -13,14 +14,14 @@ use Saloon\Http\BaseResource;
 
 final class StatsResource extends BaseResource
 {
-    public function achievements(SteamId $steamId, int $appId, ?string $language = null): PlayerAchievements
+    public function achievements(SteamId $steamId, int $appId, ?Language $language = null): PlayerAchievements
     {
         $request = new GetPlayerAchievementsRequest($steamId, $appId, $language);
 
         return $request->createDtoFromResponse($this->connector->send($request));
     }
 
-    public function userStats(SteamId $steamId, int $appId, ?string $language = null): UserStats
+    public function userStats(SteamId $steamId, int $appId, ?Language $language = null): UserStats
     {
         $request = new GetUserStatsForGameRequest($steamId, $appId, $language);
 

--- a/src/SteamConfig.php
+++ b/src/SteamConfig.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Fkrzski\SteamApiSdk;
 
+use Fkrzski\SteamApiSdk\Enums\Language;
 use Saloon\RateLimitPlugin\Contracts\RateLimitStore;
 
 final readonly class SteamConfig
@@ -11,5 +12,6 @@ final readonly class SteamConfig
     public function __construct(
         public string $apiKey,
         public ?RateLimitStore $rateLimitStore = null,
+        public ?Language $language = null,
     ) {}
 }

--- a/src/SteamConnector.php
+++ b/src/SteamConnector.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Fkrzski\SteamApiSdk;
 
+use Fkrzski\SteamApiSdk\Contracts\HasLanguage;
+use Fkrzski\SteamApiSdk\Enums\Language;
 use Fkrzski\SteamApiSdk\Exceptions\InvalidApiKeyException;
 use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
 use Fkrzski\SteamApiSdk\Exceptions\SteamApiException;
@@ -13,6 +15,7 @@ use Fkrzski\SteamApiSdk\Http\Resources\StatsResource;
 use Fkrzski\SteamApiSdk\Http\Resources\UsersResource;
 use Override;
 use Saloon\Http\Connector;
+use Saloon\Http\PendingRequest;
 use Saloon\Http\Response;
 use Saloon\RateLimitPlugin\Contracts\RateLimitStore;
 use Saloon\RateLimitPlugin\Limit;
@@ -48,6 +51,23 @@ class SteamConnector extends Connector
     public function stats(): StatsResource
     {
         return new StatsResource($this);
+    }
+
+    /**
+     * Saloon merges the request query before booting, so the configured default only
+     * fills the gap a request left open — an explicit language always wins.
+     */
+    public function boot(PendingRequest $pendingRequest): void
+    {
+        $request = $pendingRequest->getRequest();
+
+        if (! $request instanceof HasLanguage || $request->language instanceof Language) {
+            return;
+        }
+
+        if ($this->steamConfig->language instanceof Language) {
+            $pendingRequest->query()->add('l', $this->steamConfig->language->value);
+        }
     }
 
     /**

--- a/tests/Architecture/ArchitectureTest.php
+++ b/tests/Architecture/ArchitectureTest.php
@@ -31,6 +31,10 @@ arch('value objects are final readonly classes')
     ->toBeFinal()
     ->toBeReadonly();
 
+arch('contracts are interfaces')
+    ->expect('Fkrzski\SteamApiSdk\Contracts')
+    ->toBeInterfaces();
+
 arch('enums are backed enums')
     ->expect('Fkrzski\SteamApiSdk\Enums')
     ->toBeEnums();

--- a/tests/Feature/Http/Requests/ISteamUserStats/GetPlayerAchievementsRequestTest.php
+++ b/tests/Feature/Http/Requests/ISteamUserStats/GetPlayerAchievementsRequestTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Fkrzski\SteamApiSdk\Dto\PlayerAchievement;
 use Fkrzski\SteamApiSdk\Dto\PlayerAchievements;
+use Fkrzski\SteamApiSdk\Enums\Language;
 use Fkrzski\SteamApiSdk\Exceptions\InvalidApiKeyException;
 use Fkrzski\SteamApiSdk\Exceptions\StatsUnavailableException;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetPlayerAchievementsRequest;
@@ -41,9 +42,9 @@ test('query includes steamid and appid', function (): void {
 });
 
 test('query includes language when provided', function (): void {
-    $request = new GetPlayerAchievementsRequest(playerAchievementsSteamId(), 381210, 'pl');
+    $request = new GetPlayerAchievementsRequest(playerAchievementsSteamId(), 381210, Language::Polish);
 
-    expect($request->query()->all())->toMatchArray(['l' => 'pl']);
+    expect($request->query()->all())->toMatchArray(['l' => 'polish']);
 });
 
 test('query omits language when null', function (): void {
@@ -98,7 +99,7 @@ test('localized fixture populates name and description', function (): void {
     $connector->withMockClient($mock);
 
     /** @var PlayerAchievements $dto */
-    $dto = $connector->send(new GetPlayerAchievementsRequest(playerAchievementsSteamId(), 381210, 'english'))->dto();
+    $dto = $connector->send(new GetPlayerAchievementsRequest(playerAchievementsSteamId(), 381210, Language::English))->dto();
 
     expect($dto->achievements[0]->name)->toBe('I Am Inevitable')
         ->and($dto->achievements[0]->description)->toBe('Sacrifice 4 Survivors in a single match.');

--- a/tests/Feature/Http/Requests/ISteamUserStats/GetUserStatsForGameRequestTest.php
+++ b/tests/Feature/Http/Requests/ISteamUserStats/GetUserStatsForGameRequestTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Fkrzski\SteamApiSdk\Dto\UserStat;
 use Fkrzski\SteamApiSdk\Dto\UserStatAchievement;
 use Fkrzski\SteamApiSdk\Dto\UserStats;
+use Fkrzski\SteamApiSdk\Enums\Language;
 use Fkrzski\SteamApiSdk\Exceptions\InvalidApiKeyException;
 use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetUserStatsForGameRequest;
@@ -42,9 +43,9 @@ test('query includes steamid and appid', function (): void {
 });
 
 test('query includes language when provided', function (): void {
-    $request = new GetUserStatsForGameRequest(userStatsSteamId(), 381210, 'pl');
+    $request = new GetUserStatsForGameRequest(userStatsSteamId(), 381210, Language::Polish);
 
-    expect($request->query()->all())->toMatchArray(['l' => 'pl']);
+    expect($request->query()->all())->toMatchArray(['l' => 'polish']);
 });
 
 test('query omits language when null', function (): void {

--- a/tests/Feature/Http/Resources/StatsResourceTest.php
+++ b/tests/Feature/Http/Resources/StatsResourceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Fkrzski\SteamApiSdk\Dto\PlayerAchievements;
 use Fkrzski\SteamApiSdk\Dto\UserStats;
+use Fkrzski\SteamApiSdk\Enums\Language;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetPlayerAchievementsRequest;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetUserStatsForGameRequest;
 use Fkrzski\SteamApiSdk\Http\Resources\StatsResource;
@@ -56,7 +57,7 @@ test('achievements forwards the language', function (): void {
         'ISteamUserStats/GetPlayerAchievements/localized',
     );
 
-    statsResource($mockClient)->achievements(statsResourceSteamId(), 381210, 'polish');
+    statsResource($mockClient)->achievements(statsResourceSteamId(), 381210, Language::Polish);
 
     expect($mockClient->getLastRequest()?->query()->all())->toBe([
         'steamid' => '76561198148125221',
@@ -88,7 +89,7 @@ test('userStats forwards the language', function (): void {
         'ISteamUserStats/GetUserStatsForGame/default',
     );
 
-    statsResource($mockClient)->userStats(statsResourceSteamId(), 381210, 'polish');
+    statsResource($mockClient)->userStats(statsResourceSteamId(), 381210, Language::Polish);
 
     expect($mockClient->getLastRequest()?->query()->all())->toBe([
         'steamid' => '76561198148125221',

--- a/tests/Feature/SteamConnectorTest.php
+++ b/tests/Feature/SteamConnectorTest.php
@@ -2,10 +2,12 @@
 
 declare(strict_types=1);
 
+use Fkrzski\SteamApiSdk\Enums\Language;
 use Fkrzski\SteamApiSdk\Exceptions\InvalidApiKeyException;
 use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
 use Fkrzski\SteamApiSdk\Exceptions\SteamApiException;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetFriendListRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetPlayerAchievementsRequest;
 use Fkrzski\SteamApiSdk\Http\Resources\PlayersResource;
 use Fkrzski\SteamApiSdk\Http\Resources\StatsResource;
 use Fkrzski\SteamApiSdk\Http\Resources\UsersResource;
@@ -15,6 +17,7 @@ use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
 use Saloon\Http\Faking\Fixture;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
+use Saloon\Http\Request;
 use Saloon\RateLimitPlugin\Limit;
 use Saloon\RateLimitPlugin\Stores\MemoryStore;
 use Saloon\Traits\Plugins\AlwaysThrowOnErrors;
@@ -70,6 +73,39 @@ test('resolveRateLimitStore falls back to a fresh in-memory store', function ():
     $rateLimitStore = $connector->rateLimitStore();
 
     expect($rateLimitStore)->toBeInstanceOf(MemoryStore::class);
+});
+
+/**
+ * @return array<string, mixed>
+ */
+function bootedQuery(?Language $configured, Request $request): array
+{
+    $connector = new SteamConnector(new SteamConfig('any', language: $configured));
+
+    return $connector->createPendingRequest($request)->query()->all();
+}
+
+function achievementsRequest(?Language $language = null): GetPlayerAchievementsRequest
+{
+    return new GetPlayerAchievementsRequest(SteamId::fromSteamId64('76561198148125221'), 381210, $language);
+}
+
+test('the configured language fills in the l parameter a request left open', function (): void {
+    expect(bootedQuery(Language::Polish, achievementsRequest()))->toHaveKey('l', 'polish');
+});
+
+test('a language passed to the request wins over the configured one', function (): void {
+    expect(bootedQuery(Language::Polish, achievementsRequest(Language::English)))->toHaveKey('l', 'english');
+});
+
+test('endpoints that do not take a language never receive one', function (): void {
+    $query = bootedQuery(Language::Polish, new GetFriendListRequest(SteamId::fromSteamId64('76561198148125221')));
+
+    expect($query)->not->toHaveKey('l');
+});
+
+test('without a configured language the parameter stays off', function (): void {
+    expect(bootedQuery(null, achievementsRequest()))->not->toHaveKey('l');
 });
 
 /**

--- a/tests/Unit/Enums/LanguageTest.php
+++ b/tests/Unit/Enums/LanguageTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Fkrzski\SteamApiSdk\Enums\Language;
+
+covers(Language::class);
+
+test('backing values are Steam codes, not ISO ones', function (Language $language, string $expected): void {
+    expect($language->value)->toBe($expected);
+})->with([
+    'simplified chinese' => [Language::ChineseSimplified, 'schinese'],
+    'traditional chinese' => [Language::ChineseTraditional, 'tchinese'],
+    'korean' => [Language::Korean, 'koreana'],
+    'brazilian portuguese' => [Language::PortugueseBrazil, 'brazilian'],
+    'latin american spanish' => [Language::SpanishLatinAmerican, 'latam'],
+]);
+
+test('the plain cases back onto their lowercased name', function (Language $language): void {
+    expect($language->value)->toBe(strtolower($language->name));
+})->with([
+    'english' => [Language::English],
+    'polish' => [Language::Polish],
+    'japanese' => [Language::Japanese],
+    'ukrainian' => [Language::Ukrainian],
+]);
+
+test('the enum transcribes the whole Steam table', function (): void {
+    expect(Language::cases())->toHaveCount(30)
+        ->and(Language::tryFrom('english'))->toBe(Language::English)
+        ->and(Language::tryFrom('portuguese'))->toBe(Language::Portuguese)
+        ->and(Language::tryFrom('pt-BR'))->toBeNull();
+});
+
+test('a case survives json_encode as its Steam code', function (): void {
+    expect(json_encode(Language::Korean, JSON_THROW_ON_ERROR))->toBe('"koreana"');
+});

--- a/tests/Unit/SteamConfigTest.php
+++ b/tests/Unit/SteamConfigTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Fkrzski\SteamApiSdk\Enums\Language;
 use Fkrzski\SteamApiSdk\SteamConfig;
 
 covers(SteamConfig::class);
@@ -17,4 +18,16 @@ test('SteamConfig is readonly', function (): void {
 
     expect($reflection->isReadOnly())->toBeTrue()
         ->and($reflection->isFinal())->toBeTrue();
+});
+
+test('SteamConfig has no default language until one is set', function (): void {
+    $config = new SteamConfig(apiKey: 'test-key');
+
+    expect($config->language)->toBeNull();
+});
+
+test('SteamConfig stores the default language', function (): void {
+    $config = new SteamConfig(apiKey: 'test-key', language: Language::Polish);
+
+    expect($config->language)->toBe(Language::Polish);
 });


### PR DESCRIPTION
## Summary

A `Language` enum over Steam's `l` query parameter, plus a `language` on `SteamConfig` that
applies to every request whose endpoint localises its payload.

- `feat(enums)` — `Language`, 30 cases backed by Valve's codes. They are not ISO, so five
  cases are named for the language and backed by Steam's spelling: `ChineseSimplified`
  (`'schinese'`), `ChineseTraditional` (`'tchinese'`), `Korean` (`'koreana'`),
  `PortugueseBrazil` (`'brazilian'`), `SpanishLatinAmerican` (`'latam'`).
- `refactor(stats)` — **BC break.** `$language` is a `?Language` instead of a `?string` on
  `GetPlayerAchievementsRequest`, `GetUserStatsForGameRequest` and both `StatsResource`
  methods. Callers passing a raw code swap `'english'` for `Language::English`.
- `feat(config)` — `SteamConfig::$language`, resolved in `SteamConnector::boot()` against the
  new `HasLanguage` contract. An explicit argument always wins, and endpoints that do not
  localise anything never receive `l`.
- `docs` — the enum in the DTO reference, a *Default language* section in Configuration,
  updated signatures in the API reference, and the CHANGELOG entry.

## Why

`?string $language` accepted anything and validated nothing, while Steam's codes are Valve's
own rather than ISO — `'pt-BR'` or `'ko'` silently returned unlocalised payloads. The default
lives on the config because a language is an application-wide choice, not a per-call one.

Resolution sits in the connector's `boot()` rather than in the resources so the default also
reaches a request the caller constructed and sent themselves, which the docs present as an
equal path to the resource methods.

`GetSchemaForGame` and the rest of `ISteamUserStats` are out of scope — this lands first so
they are written against the enum from the start.

Closes #46
