### PR TITLE
Add GetNumberOfCurrentPlayers and AppNotFoundException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `AppNotFoundException` for an app ID Steam does not know, thrown only where the response separates it from an app that merely exposes no stats. The `400` on `GetPlayerAchievementsRequest` does not, so it keeps `StatsUnavailableException` ([#47](https://github.com/fkrzski/php-steam-api-sdk/issues/47)).
+- `GetNumberOfCurrentPlayersRequest` (`ISteamUserStats`) returning a game's concurrent player count as a plain `int`. Steam serves the endpoint anonymously, so requests implementing the new `SendsNoApiKey` contract go out with the configured key stripped from the query ([#49](https://github.com/fkrzski/php-steam-api-sdk/issues/49)).
 - `Language` enum backing Steam's `l` query parameter, and a `language` on `SteamConfig` that applies it to every request whose endpoint localises its payload. Steam's codes are Valve's own rather than ISO, so the enum transcribes their table instead of mapping to one ([#46](https://github.com/fkrzski/php-steam-api-sdk/issues/46)).
 
 ### Changed

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -35,6 +35,7 @@ interface, and one request class per endpoint:
       - GetUserGroupListRequest.php
       - ResolveVanityUrlRequest.php
     - ISteamUserStats
+      - GetNumberOfCurrentPlayersRequest.php
       - GetPlayerAchievementsRequest.php
       - GetUserStatsForGameRequest.php
   - Resources
@@ -49,6 +50,7 @@ interface, and one request class per endpoint:
 | [`GetBadgesRequest`](#getbadgesrequest) | `players()->badges()` | `PlayerBadges` |
 | [`GetCommunityBadgeProgressRequest`](#getcommunitybadgeprogressrequest) | `players()->communityBadgeProgress()` | `list<CommunityBadgeQuest>` |
 | [`GetFriendListRequest`](#getfriendlistrequest) | `users()->friends()` | `list<Friend>` |
+| [`GetNumberOfCurrentPlayersRequest`](#getnumberofcurrentplayersrequest) | `stats()->currentPlayers()` | `int` |
 | [`GetOwnedGamesRequest`](#getownedgamesrequest) | `players()->ownedGames()` | `list<OwnedGame>` |
 | [`GetPlayerAchievementsRequest`](#getplayerachievementsrequest) | `stats()->achievements()` | `PlayerAchievements` |
 | [`GetPlayerBansRequest`](#getplayerbansrequest) | `users()->bans()` | `list<PlayerBan>` |
@@ -138,6 +140,28 @@ use Fkrzski\SteamApiSdk\Enums\FriendRelationship;
 
 $friends = $connector->users()->friends($steamId, FriendRelationship::Friend);
 ```
+
+## GetNumberOfCurrentPlayersRequest
+
+```text frame="none"
+$connector->stats()->currentPlayers(int $appId)
+
+new GetNumberOfCurrentPlayersRequest($appId)
+```
+
+<p><Badge text="ISteamUserStats" variant="note" size="small" />{' '}<Badge text="throws AppNotFoundException" variant="danger" size="small" /></p>
+
+How many people are playing a game right now, as a plain `int` rather than a DTO. Steam
+serves it anonymously, so the SDK keeps the configured key out of this one query.
+
+```php
+$players = $connector->stats()->currentPlayers(381210);
+```
+
+<Aside type="caution" title="App ID 0 answers with the Steam-wide total">
+Steam reads `appid: 0` as a query about the whole platform and returns everyone online
+across it. An app ID it does not know raises the exception instead.
+</Aside>
 
 ## GetOwnedGamesRequest
 

--- a/docs/guide.mdx
+++ b/docs/guide.mdx
@@ -90,6 +90,7 @@ Every SDK failure extends `SteamApiException`, so one catch handles them all:
 
 ```text frame="none"
 SteamApiException                (root, extends RuntimeException)
+├── AppNotFoundException         No Steam app carries the given app ID.
 ├── InvalidApiKeyException       API key missing, wrong, or revoked.
 ├── InvalidSteamIdException      Malformed SteamID64.
 ├── ProfileNotPublicException    Profile, games list, groups, or stats are private.
@@ -167,6 +168,7 @@ Steam signals failure in two different ways, and the SDK reads both:
 | `401` or `403` + HTML naming the `key` parameter | `InvalidApiKeyException` (rejected) |
 | `400` + JSON, on `ISteamUserStats` | `StatsUnavailableException` / `ProfileNotPublicException` |
 | `401` or `403` not naming the `key` parameter | `ProfileNotPublicException` |
+| `404` + JSON, on `ISteamUserStats` | `AppNotFoundException` |
 | `429` | `SteamRateLimitException` |
 | any other `4xx` / `5xx` | `SteamApiException` |
 | `200` with an empty or `success: 42` payload | `ProfileNotPublicException` / `SteamUserNotFoundException` |

--- a/src/Contracts/SendsNoApiKey.php
+++ b/src/Contracts/SendsNoApiKey.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Contracts;
+
+/**
+ * Marks an endpoint Steam serves anonymously, so the connector keeps the configured
+ * key out of its query.
+ */
+interface SendsNoApiKey {}

--- a/src/Exceptions/AppNotFoundException.php
+++ b/src/Exceptions/AppNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Exceptions;
+
+use Saloon\Http\Response;
+
+final class AppNotFoundException extends SteamApiException
+{
+    public static function forAppId(int $appId, Response $response): self
+    {
+        return new self(sprintf('No Steam app found for app ID %d.', $appId), $response);
+    }
+}

--- a/src/Http/Requests/ISteamUserStats/GetNumberOfCurrentPlayersRequest.php
+++ b/src/Http/Requests/ISteamUserStats/GetNumberOfCurrentPlayersRequest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats;
+
+use Fkrzski\SteamApiSdk\Contracts\SendsNoApiKey;
+use Fkrzski\SteamApiSdk\Exceptions\AppNotFoundException;
+use Override;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use Throwable;
+
+final class GetNumberOfCurrentPlayersRequest extends Request implements SendsNoApiKey
+{
+    #[Override]
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        public readonly int $appId,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return '/ISteamUserStats/GetNumberOfCurrentPlayers/v1/';
+    }
+
+    /**
+     * An app Steam does not know answers 404 with `result: 42` and no count, which the
+     * connector would otherwise flatten into a bare SteamApiException.
+     */
+    #[Override]
+    public function getRequestException(Response $response, ?Throwable $senderException): ?Throwable
+    {
+        if ($response->status() !== 404) {
+            return null;
+        }
+
+        return AppNotFoundException::forAppId($this->appId, $response);
+    }
+
+    public function createDtoFromResponse(Response $response): int
+    {
+        /** @var array{response: array{player_count: int}} $body */
+        $body = $response->json();
+
+        return $body['response']['player_count'];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    protected function defaultQuery(): array
+    {
+        return [
+            'appid' => $this->appId,
+        ];
+    }
+}

--- a/src/Http/Resources/StatsResource.php
+++ b/src/Http/Resources/StatsResource.php
@@ -7,6 +7,7 @@ namespace Fkrzski\SteamApiSdk\Http\Resources;
 use Fkrzski\SteamApiSdk\Dto\PlayerAchievements;
 use Fkrzski\SteamApiSdk\Dto\UserStats;
 use Fkrzski\SteamApiSdk\Enums\Language;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetNumberOfCurrentPlayersRequest;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetPlayerAchievementsRequest;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetUserStatsForGameRequest;
 use Fkrzski\SteamApiSdk\ValueObjects\SteamId;
@@ -17,6 +18,13 @@ final class StatsResource extends BaseResource
     public function achievements(SteamId $steamId, int $appId, ?Language $language = null): PlayerAchievements
     {
         $request = new GetPlayerAchievementsRequest($steamId, $appId, $language);
+
+        return $request->createDtoFromResponse($this->connector->send($request));
+    }
+
+    public function currentPlayers(int $appId): int
+    {
+        $request = new GetNumberOfCurrentPlayersRequest($appId);
 
         return $request->createDtoFromResponse($this->connector->send($request));
     }

--- a/src/SteamConnector.php
+++ b/src/SteamConnector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Fkrzski\SteamApiSdk;
 
 use Fkrzski\SteamApiSdk\Contracts\HasLanguage;
+use Fkrzski\SteamApiSdk\Contracts\SendsNoApiKey;
 use Fkrzski\SteamApiSdk\Enums\Language;
 use Fkrzski\SteamApiSdk\Exceptions\InvalidApiKeyException;
 use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
@@ -54,12 +55,17 @@ class SteamConnector extends Connector
     }
 
     /**
-     * Saloon merges the request query before booting, so the configured default only
-     * fills the gap a request left open — an explicit language always wins.
+     * Saloon merges the request query before booting, so both defaults act on a query
+     * that is already complete: the key can be taken back out, and the configured
+     * language only fills the gap a request left open — an explicit one always wins.
      */
     public function boot(PendingRequest $pendingRequest): void
     {
         $request = $pendingRequest->getRequest();
+
+        if ($request instanceof SendsNoApiKey) {
+            $pendingRequest->query()->remove('key');
+        }
 
         if (! $request instanceof HasLanguage || $request->language instanceof Language) {
             return;

--- a/tests/Feature/Http/Requests/ISteamUserStats/GetNumberOfCurrentPlayersRequestTest.php
+++ b/tests/Feature/Http/Requests/ISteamUserStats/GetNumberOfCurrentPlayersRequestTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use Fkrzski\SteamApiSdk\Exceptions\AppNotFoundException;
+use Fkrzski\SteamApiSdk\Exceptions\SteamApiException;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetNumberOfCurrentPlayersRequest;
+use Fkrzski\SteamApiSdk\SteamConfig;
+use Fkrzski\SteamApiSdk\SteamConnector;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+covers([GetNumberOfCurrentPlayersRequest::class, AppNotFoundException::class]);
+
+function sendCurrentPlayersFixture(string $fixture, int $appId = 381210): int
+{
+    $connector = new SteamConnector(new SteamConfig('test-key'));
+    $connector->withMockClient(new MockClient([
+        GetNumberOfCurrentPlayersRequest::class => MockResponse::fixture(
+            sprintf('ISteamUserStats/GetNumberOfCurrentPlayers/%s', $fixture),
+        ),
+    ]));
+
+    /** @var int $count */
+    $count = $connector->send(new GetNumberOfCurrentPlayersRequest($appId))->dto();
+
+    return $count;
+}
+
+test('endpoint targets GetNumberOfCurrentPlayers v1', function (): void {
+    $request = new GetNumberOfCurrentPlayersRequest(381210);
+
+    expect($request->resolveEndpoint())->toBe('/ISteamUserStats/GetNumberOfCurrentPlayers/v1/');
+});
+
+test('query carries appid parameter', function (): void {
+    $request = new GetNumberOfCurrentPlayersRequest(381210);
+
+    expect($request->query()->all())->toBe(['appid' => 381210]);
+});
+
+test('fixture response yields the player count as an int', function (): void {
+    expect(sendCurrentPlayersFixture('default'))->toBe(40008);
+});
+
+test('app id zero yields the Steam-wide concurrent total', function (): void {
+    expect(sendCurrentPlayersFixture('steam-wide', 0))->toBe(24453426);
+});
+
+test('unknown app throws AppNotFoundException', function (): void {
+    sendCurrentPlayersFixture('unknown-app', 999999999);
+})->throws(
+    AppNotFoundException::class,
+    'No Steam app found for app ID 999999999.',
+);
+
+test('a failure other than 404 is left to the connector', function (): void {
+    $connector = new SteamConnector(new SteamConfig('test-key'));
+    $connector->withMockClient(new MockClient([
+        GetNumberOfCurrentPlayersRequest::class => MockResponse::make([], 500),
+    ]));
+
+    $connector->send(new GetNumberOfCurrentPlayersRequest(381210));
+})->throws(
+    SteamApiException::class,
+    'Steam API request failed with HTTP 500.',
+);

--- a/tests/Feature/Http/Resources/StatsResourceTest.php
+++ b/tests/Feature/Http/Resources/StatsResourceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Fkrzski\SteamApiSdk\Dto\PlayerAchievements;
 use Fkrzski\SteamApiSdk\Dto\UserStats;
 use Fkrzski\SteamApiSdk\Enums\Language;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetNumberOfCurrentPlayersRequest;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetPlayerAchievementsRequest;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetUserStatsForGameRequest;
 use Fkrzski\SteamApiSdk\Http\Resources\StatsResource;
@@ -64,6 +65,18 @@ test('achievements forwards the language', function (): void {
         'appid' => 381210,
         'l' => 'polish',
     ]);
+});
+
+test('currentPlayers sends GetNumberOfCurrentPlayers and returns the count', function (): void {
+    $mockClient = statsResourceMock(
+        GetNumberOfCurrentPlayersRequest::class,
+        'ISteamUserStats/GetNumberOfCurrentPlayers/default',
+    );
+
+    $count = statsResource($mockClient)->currentPlayers(381210);
+
+    expect($count)->toBe(40008)
+        ->and($mockClient->getLastRequest()?->query()->all())->toBe(['appid' => 381210]);
 });
 
 test('userStats sends GetUserStatsForGame and returns the DTO', function (): void {

--- a/tests/Feature/SteamConnectorTest.php
+++ b/tests/Feature/SteamConnectorTest.php
@@ -7,6 +7,7 @@ use Fkrzski\SteamApiSdk\Exceptions\InvalidApiKeyException;
 use Fkrzski\SteamApiSdk\Exceptions\ProfileNotPublicException;
 use Fkrzski\SteamApiSdk\Exceptions\SteamApiException;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUser\GetFriendListRequest;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetNumberOfCurrentPlayersRequest;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetPlayerAchievementsRequest;
 use Fkrzski\SteamApiSdk\Http\Resources\PlayersResource;
 use Fkrzski\SteamApiSdk\Http\Resources\StatsResource;
@@ -106,6 +107,17 @@ test('endpoints that do not take a language never receive one', function (): voi
 
 test('without a configured language the parameter stays off', function (): void {
     expect(bootedQuery(null, achievementsRequest()))->not->toHaveKey('l');
+});
+
+test('a request Steam serves anonymously goes out without the key', function (): void {
+    $query = bootedQuery(null, new GetNumberOfCurrentPlayersRequest(381210));
+
+    expect($query)->not->toHaveKey('key')
+        ->and($query)->toHaveKey('appid', 381210);
+});
+
+test('every other request keeps the configured key', function (): void {
+    expect(bootedQuery(null, achievementsRequest()))->toHaveKey('key', 'any');
 });
 
 /**

--- a/tests/Fixtures/Saloon/ISteamUserStats/GetNumberOfCurrentPlayers/default.json
+++ b/tests/Fixtures/Saloon/ISteamUserStats/GetNumberOfCurrentPlayers/default.json
@@ -1,0 +1,12 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "response": {
+            "player_count": 40008,
+            "result": 1
+        }
+    }
+}

--- a/tests/Fixtures/Saloon/ISteamUserStats/GetNumberOfCurrentPlayers/steam-wide.json
+++ b/tests/Fixtures/Saloon/ISteamUserStats/GetNumberOfCurrentPlayers/steam-wide.json
@@ -1,0 +1,12 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "response": {
+            "player_count": 24453426,
+            "result": 1
+        }
+    }
+}

--- a/tests/Fixtures/Saloon/ISteamUserStats/GetNumberOfCurrentPlayers/unknown-app.json
+++ b/tests/Fixtures/Saloon/ISteamUserStats/GetNumberOfCurrentPlayers/unknown-app.json
@@ -1,0 +1,11 @@
+{
+    "statusCode": 404,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "response": {
+            "result": 42
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `GetNumberOfCurrentPlayersRequest` (`ISteamUserStats`), reachable as `$connector->stats()->currentPlayers($appId)` and returning a plain `int` the way `GetSteamLevelRequest` does.
- `AppNotFoundException` for an app ID Steam does not know. The `404` here separates that from an app which merely exposes no stats; the `400` on `GetPlayerAchievementsRequest` does not, so it keeps `StatsUnavailableException`.
- `SendsNoApiKey` contract, and a connector that strips `key` from the query of every request carrying it.

## Why

Steam serves this endpoint anonymously, so sending the configured key can only ever spend quota against it. The rate limiter still counts these calls on purpose: `bootHasRateLimits()` is all-or-nothing per request, so exempting them would also drop the plugin's `429` detection — and anonymous traffic, throttled per IP, is what needs it most.

`appid: 0` turned out not to be an error. Steam reads it as a query about the whole platform and answers with the concurrent player count across all of Steam, so it is documented and pinned by a fixture rather than guarded against, matching how level `0` is handled on `GetSteamLevelRequest`.

No BC break.

Closes #47
Closes #49
