### PR TITLE
Add GetGlobalAchievementPercentagesForApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `AppNotFoundException` for an app ID Steam does not know, thrown only where the response separates it from an app that merely exposes no stats. The `400` on `GetPlayerAchievementsRequest` does not, so it keeps `StatsUnavailableException` ([#47](https://github.com/fkrzski/php-steam-api-sdk/issues/47)).
+- `GetGlobalAchievementPercentagesForAppRequest` (`ISteamUserStats`) with the `GlobalAchievement` DTO, listing how much of the playerbase has unlocked each achievement in a game. Steam spells the parameter `gameid` rather than `appid` and the SDK follows, so this one method takes `$gameId`; `403` comes back identically for a game carrying no achievements and for a game ID Steam does not know, so both raise `StatsUnavailableException` ([#50](https://github.com/fkrzski/php-steam-api-sdk/issues/50)).
 - `GetNumberOfCurrentPlayersRequest` (`ISteamUserStats`) returning a game's concurrent player count as a plain `int`. Steam serves the endpoint anonymously, so requests implementing the new `SendsNoApiKey` contract go out with the configured key stripped from the query ([#49](https://github.com/fkrzski/php-steam-api-sdk/issues/49)).
 - `Language` enum backing Steam's `l` query parameter, and a `language` on `SteamConfig` that applies it to every request whose endpoint localises its payload. Steam's codes are Valve's own rather than ISO, so the enum transcribes their table instead of mapping to one ([#46](https://github.com/fkrzski/php-steam-api-sdk/issues/46)).
 

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -35,6 +35,7 @@ interface, and one request class per endpoint:
       - GetUserGroupListRequest.php
       - ResolveVanityUrlRequest.php
     - ISteamUserStats
+      - GetGlobalAchievementPercentagesForAppRequest.php
       - GetNumberOfCurrentPlayersRequest.php
       - GetPlayerAchievementsRequest.php
       - GetUserStatsForGameRequest.php
@@ -50,6 +51,7 @@ interface, and one request class per endpoint:
 | [`GetBadgesRequest`](#getbadgesrequest) | `players()->badges()` | `PlayerBadges` |
 | [`GetCommunityBadgeProgressRequest`](#getcommunitybadgeprogressrequest) | `players()->communityBadgeProgress()` | `list<CommunityBadgeQuest>` |
 | [`GetFriendListRequest`](#getfriendlistrequest) | `users()->friends()` | `list<Friend>` |
+| [`GetGlobalAchievementPercentagesForAppRequest`](#getglobalachievementpercentagesforapprequest) | `stats()->globalAchievements()` | `list<GlobalAchievement>` |
 | [`GetNumberOfCurrentPlayersRequest`](#getnumberofcurrentplayersrequest) | `stats()->currentPlayers()` | `int` |
 | [`GetOwnedGamesRequest`](#getownedgamesrequest) | `players()->ownedGames()` | `list<OwnedGame>` |
 | [`GetPlayerAchievementsRequest`](#getplayerachievementsrequest) | `stats()->achievements()` | `PlayerAchievements` |
@@ -140,6 +142,35 @@ use Fkrzski\SteamApiSdk\Enums\FriendRelationship;
 
 $friends = $connector->users()->friends($steamId, FriendRelationship::Friend);
 ```
+
+## GetGlobalAchievementPercentagesForAppRequest
+
+```text frame="none"
+$connector->stats()->globalAchievements(int $gameId)
+
+new GetGlobalAchievementPercentagesForAppRequest($gameId)
+```
+
+<p><Badge text="ISteamUserStats" variant="note" size="small" />{' '}<Badge text="throws StatsUnavailableException" variant="danger" size="small" /></p>
+
+How much of the playerbase has unlocked each achievement in a game, ordered from the most
+common down. Steam serves it anonymously, so the SDK keeps the configured key out of this
+one query. The exception covers two causes — a game carrying no achievements, or a game ID
+Steam does not know — because both answer identically.
+
+```php
+$achievements = $connector->stats()->globalAchievements(381210);
+
+foreach ($achievements as $achievement) {
+    echo $achievement->apiName, ' — ', $achievement->percent, '%', PHP_EOL;
+}
+```
+
+<Aside type="caution" title="The parameter is gameid, not appid">
+Steam spells this one `gameid`, the only endpoint in the SDK that does, and the SDK follows
+it: the argument is `$gameId` where every other app-scoped method takes `$appId`. The value
+is an ordinary app ID.
+</Aside>
 
 ## GetNumberOfCurrentPlayersRequest
 

--- a/docs/dto-reference.mdx
+++ b/docs/dto-reference.mdx
@@ -29,6 +29,15 @@ Returned by [`GetFriendListRequest`](/php-steam-api-sdk/api-reference#getfriendl
 | `relationship` | `FriendRelationship` | Relationship to the queried user. |
 | `friendSince` | `DateTimeImmutable` | When the friendship was formed. |
 
+## GlobalAchievement
+
+Returned by [`GetGlobalAchievementPercentagesForAppRequest`](/php-steam-api-sdk/api-reference#getglobalachievementpercentagesforapprequest).
+
+| Property | Type | Notes |
+| --- | --- | --- |
+| `apiName` | `string` | Stable API identifier, same one `PlayerAchievement` carries. |
+| `percent` | `float` | Share of owners who unlocked it. Steam sends it as a string. |
+
 ## OwnedGame
 
 Returned by [`GetOwnedGamesRequest`](/php-steam-api-sdk/api-reference#getownedgamesrequest).

--- a/docs/guide.mdx
+++ b/docs/guide.mdx
@@ -94,7 +94,7 @@ SteamApiException                (root, extends RuntimeException)
 ├── InvalidApiKeyException       API key missing, wrong, or revoked.
 ├── InvalidSteamIdException      Malformed SteamID64.
 ├── ProfileNotPublicException    Profile, games list, groups, or stats are private.
-├── StatsUnavailableException    Stats withheld: no such stats, or private profile.
+├── StatsUnavailableException    Stats withheld: none exist, unknown app, or private profile.
 ├── SteamRateLimitException      Daily 100k quota reached; exposes the offending Limit.
 ├── SteamUserNotFoundException   Vanity URL unresolved or profile missing.
 └── TooManySteamIdsException     More than 100 IDs in a batch request.
@@ -166,7 +166,7 @@ Steam signals failure in two different ways, and the SDK reads both:
 | --- | --- |
 | `400` + HTML naming the `key` parameter | `InvalidApiKeyException` (missing) |
 | `401` or `403` + HTML naming the `key` parameter | `InvalidApiKeyException` (rejected) |
-| `400` + JSON, on `ISteamUserStats` | `StatsUnavailableException` / `ProfileNotPublicException` |
+| `400` or `403` + JSON, on `ISteamUserStats` | `StatsUnavailableException` / `ProfileNotPublicException` |
 | `401` or `403` not naming the `key` parameter | `ProfileNotPublicException` |
 | `404` + JSON, on `ISteamUserStats` | `AppNotFoundException` |
 | `429` | `SteamRateLimitException` |

--- a/src/Dto/GlobalAchievement.php
+++ b/src/Dto/GlobalAchievement.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Dto;
+
+final readonly class GlobalAchievement
+{
+    public function __construct(
+        public string $apiName,
+        public float $percent,
+    ) {}
+
+    /**
+     * @param  array{name: string, percent: string}  $payload
+     */
+    public static function fromArray(array $payload): self
+    {
+        return new self(
+            apiName: $payload['name'],
+            percent: (float) $payload['percent'],
+        );
+    }
+}

--- a/src/Exceptions/StatsUnavailableException.php
+++ b/src/Exceptions/StatsUnavailableException.php
@@ -15,4 +15,12 @@ final class StatsUnavailableException extends SteamApiException
             $response,
         );
     }
+
+    public static function forGlobalAchievements(int $gameId, Response $response): self
+    {
+        return new self(
+            sprintf('Steam returned no global achievements for game %d: it carries none, or no game has that ID.', $gameId),
+            $response,
+        );
+    }
 }

--- a/src/Http/Requests/ISteamUserStats/GetGlobalAchievementPercentagesForAppRequest.php
+++ b/src/Http/Requests/ISteamUserStats/GetGlobalAchievementPercentagesForAppRequest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats;
+
+use Fkrzski\SteamApiSdk\Contracts\SendsNoApiKey;
+use Fkrzski\SteamApiSdk\Dto\GlobalAchievement;
+use Fkrzski\SteamApiSdk\Exceptions\StatsUnavailableException;
+use Override;
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+use Saloon\Http\Response;
+use Throwable;
+
+final class GetGlobalAchievementPercentagesForAppRequest extends Request implements SendsNoApiKey
+{
+    #[Override]
+    protected Method $method = Method::GET;
+
+    /**
+     * Valve spells this endpoint's identifier `gameid`; the value is an ordinary app ID.
+     */
+    public function __construct(
+        public readonly int $gameId,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return '/ISteamUserStats/GetGlobalAchievementPercentagesForApp/v2/';
+    }
+
+    /**
+     * Steam answers 403 with an empty JSON object for a game carrying no achievements
+     * and for a game ID it does not know alike, so the cause cannot be recovered. No key
+     * goes out on this endpoint, which is what leaves every 403 to this request.
+     */
+    #[Override]
+    public function getRequestException(Response $response, ?Throwable $senderException): ?Throwable
+    {
+        if ($response->status() !== 403) {
+            return null;
+        }
+
+        return StatsUnavailableException::forGlobalAchievements($this->gameId, $response);
+    }
+
+    /**
+     * @return list<GlobalAchievement>
+     */
+    public function createDtoFromResponse(Response $response): array
+    {
+        /**
+         * @var array{achievementpercentages: array{achievements: list<array{
+         *     name: string,
+         *     percent: string,
+         * }>}} $body
+         */
+        $body = $response->json();
+
+        return array_map(GlobalAchievement::fromArray(...), $body['achievementpercentages']['achievements']);
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    protected function defaultQuery(): array
+    {
+        return [
+            'gameid' => $this->gameId,
+        ];
+    }
+}

--- a/src/Http/Resources/StatsResource.php
+++ b/src/Http/Resources/StatsResource.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Fkrzski\SteamApiSdk\Http\Resources;
 
+use Fkrzski\SteamApiSdk\Dto\GlobalAchievement;
 use Fkrzski\SteamApiSdk\Dto\PlayerAchievements;
 use Fkrzski\SteamApiSdk\Dto\UserStats;
 use Fkrzski\SteamApiSdk\Enums\Language;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetGlobalAchievementPercentagesForAppRequest;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetNumberOfCurrentPlayersRequest;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetPlayerAchievementsRequest;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetUserStatsForGameRequest;
@@ -25,6 +27,16 @@ final class StatsResource extends BaseResource
     public function currentPlayers(int $appId): int
     {
         $request = new GetNumberOfCurrentPlayersRequest($appId);
+
+        return $request->createDtoFromResponse($this->connector->send($request));
+    }
+
+    /**
+     * @return list<GlobalAchievement>
+     */
+    public function globalAchievements(int $gameId): array
+    {
+        $request = new GetGlobalAchievementPercentagesForAppRequest($gameId);
 
         return $request->createDtoFromResponse($this->connector->send($request));
     }

--- a/tests/Feature/Http/Requests/ISteamUserStats/GetGlobalAchievementPercentagesForAppRequestTest.php
+++ b/tests/Feature/Http/Requests/ISteamUserStats/GetGlobalAchievementPercentagesForAppRequestTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use Fkrzski\SteamApiSdk\Dto\GlobalAchievement;
+use Fkrzski\SteamApiSdk\Exceptions\StatsUnavailableException;
+use Fkrzski\SteamApiSdk\Exceptions\SteamApiException;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetGlobalAchievementPercentagesForAppRequest;
+use Fkrzski\SteamApiSdk\SteamConfig;
+use Fkrzski\SteamApiSdk\SteamConnector;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+covers([GetGlobalAchievementPercentagesForAppRequest::class, GlobalAchievement::class, StatsUnavailableException::class]);
+
+/**
+ * @return list<GlobalAchievement>
+ */
+function sendGlobalAchievementsFixture(string $fixture, int $gameId = 381210): array
+{
+    $connector = new SteamConnector(new SteamConfig('test-key'));
+    $connector->withMockClient(new MockClient([
+        GetGlobalAchievementPercentagesForAppRequest::class => MockResponse::fixture(
+            sprintf('ISteamUserStats/GetGlobalAchievementPercentagesForApp/%s', $fixture),
+        ),
+    ]));
+
+    /** @var list<GlobalAchievement> $achievements */
+    $achievements = $connector->send(new GetGlobalAchievementPercentagesForAppRequest($gameId))->dto();
+
+    return $achievements;
+}
+
+test('endpoint targets GetGlobalAchievementPercentagesForApp v2', function (): void {
+    $request = new GetGlobalAchievementPercentagesForAppRequest(381210);
+
+    expect($request->resolveEndpoint())->toBe('/ISteamUserStats/GetGlobalAchievementPercentagesForApp/v2/');
+});
+
+test('query carries gameid rather than appid', function (): void {
+    $request = new GetGlobalAchievementPercentagesForAppRequest(381210);
+
+    expect($request->query()->all())->toBe(['gameid' => 381210]);
+});
+
+test('fixture response maps every achievement to the DTO', function (): void {
+    $achievements = sendGlobalAchievementsFixture('default');
+
+    expect($achievements)->toHaveCount(4)
+        ->and($achievements[0])->toBeInstanceOf(GlobalAchievement::class)
+        ->and($achievements[0]->apiName)->toBe('ACH_BLOODWEB_LVL10')
+        ->and($achievements[3]->apiName)->toBe('NEW_ACHIEVEMENT_334_7');
+});
+
+test('percentages arrive as strings and become floats', function (): void {
+    $achievements = sendGlobalAchievementsFixture('default');
+
+    expect($achievements[0]->percent)->toBe(63.0)
+        ->and($achievements[2]->percent)->toBe(57.8)
+        ->and($achievements[3]->percent)->toBe(0.1);
+});
+
+test('an app with no global achievements throws StatsUnavailableException', function (): void {
+    sendGlobalAchievementsFixture('no-achievements', 2270);
+})->throws(
+    StatsUnavailableException::class,
+    'Steam returned no global achievements for game 2270: it carries none, or no game has that ID.',
+);
+
+test('an unknown game id is indistinguishable from one carrying no achievements', function (): void {
+    sendGlobalAchievementsFixture('no-achievements', 999999999);
+})->throws(
+    StatsUnavailableException::class,
+    'Steam returned no global achievements for game 999999999: it carries none, or no game has that ID.',
+);
+
+test('a failure other than 403 is left to the connector', function (): void {
+    $connector = new SteamConnector(new SteamConfig('test-key'));
+    $connector->withMockClient(new MockClient([
+        GetGlobalAchievementPercentagesForAppRequest::class => MockResponse::make([], 500),
+    ]));
+
+    $connector->send(new GetGlobalAchievementPercentagesForAppRequest(381210));
+})->throws(
+    SteamApiException::class,
+    'Steam API request failed with HTTP 500.',
+);

--- a/tests/Feature/Http/Resources/StatsResourceTest.php
+++ b/tests/Feature/Http/Resources/StatsResourceTest.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
+use Fkrzski\SteamApiSdk\Dto\GlobalAchievement;
 use Fkrzski\SteamApiSdk\Dto\PlayerAchievements;
 use Fkrzski\SteamApiSdk\Dto\UserStats;
 use Fkrzski\SteamApiSdk\Enums\Language;
+use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetGlobalAchievementPercentagesForAppRequest;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetNumberOfCurrentPlayersRequest;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetPlayerAchievementsRequest;
 use Fkrzski\SteamApiSdk\Http\Requests\ISteamUserStats\GetUserStatsForGameRequest;
@@ -77,6 +79,21 @@ test('currentPlayers sends GetNumberOfCurrentPlayers and returns the count', fun
 
     expect($count)->toBe(40008)
         ->and($mockClient->getLastRequest()?->query()->all())->toBe(['appid' => 381210]);
+});
+
+test('globalAchievements sends GetGlobalAchievementPercentagesForApp and returns the DTOs', function (): void {
+    $mockClient = statsResourceMock(
+        GetGlobalAchievementPercentagesForAppRequest::class,
+        'ISteamUserStats/GetGlobalAchievementPercentagesForApp/default',
+    );
+
+    $achievements = statsResource($mockClient)->globalAchievements(gameId: 381210);
+
+    expect($achievements)->toHaveCount(4)
+        ->and($achievements[0])->toBeInstanceOf(GlobalAchievement::class)
+        ->and($achievements[0]->apiName)->toBe('ACH_BLOODWEB_LVL10')
+        ->and($achievements[0]->percent)->toBe(63.0)
+        ->and($mockClient->getLastRequest()?->query()->all())->toBe(['gameid' => 381210]);
 });
 
 test('userStats sends GetUserStatsForGame and returns the DTO', function (): void {

--- a/tests/Fixtures/Saloon/ISteamUserStats/GetGlobalAchievementPercentagesForApp/default.json
+++ b/tests/Fixtures/Saloon/ISteamUserStats/GetGlobalAchievementPercentagesForApp/default.json
@@ -1,0 +1,28 @@
+{
+    "statusCode": 200,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {
+        "achievementpercentages": {
+            "achievements": [
+                {
+                    "name": "ACH_BLOODWEB_LVL10",
+                    "percent": "63.0"
+                },
+                {
+                    "name": "ACH_10K_POINTS_ONECATEGORY",
+                    "percent": "60.0"
+                },
+                {
+                    "name": "ACH_PERK_LVL3",
+                    "percent": "57.8"
+                },
+                {
+                    "name": "NEW_ACHIEVEMENT_334_7",
+                    "percent": "0.1"
+                }
+            ]
+        }
+    }
+}

--- a/tests/Fixtures/Saloon/ISteamUserStats/GetGlobalAchievementPercentagesForApp/no-achievements.json
+++ b/tests/Fixtures/Saloon/ISteamUserStats/GetGlobalAchievementPercentagesForApp/no-achievements.json
@@ -1,0 +1,7 @@
+{
+    "statusCode": 403,
+    "headers": {
+        "Content-Type": "application/json; charset=UTF-8"
+    },
+    "data": {}
+}


### PR DESCRIPTION
## Summary

- `feat(stats)` — `GetGlobalAchievementPercentagesForAppRequest` (`ISteamUserStats`) with the `GlobalAchievement` DTO, reachable as `stats()->globalAchievements(gameId: 381210)`. Steam serves it anonymously, so it implements `SendsNoApiKey`.
- `docs` — API reference section, `GlobalAchievement` in the data objects page, the `403` row in the status mapping table, and the CHANGELOG entry.

No BC break.

## Why

Two calls worth recording, since neither is what the issue first suggested:

**`StatsUnavailableException`, not `AppNotFoundException`.** Steam answers `403` with an empty body for a game carrying no achievements *and* for a game ID it does not know — verified against `2270`, `7670`, `32370`, `219740` and `999999999`, all identical. The rule set in #47 is that `AppNotFoundException` is thrown only where the response separates the two causes, and this one does not.

**The argument is `$gameId`, not `$appId`.** The issue notes that Valve spells this endpoint's parameter `gameid`, alone in the SDK. Naming the constructor argument `$appId` and renaming it on the wire would hide exactly the quirk the issue points at, so the name runs through unchanged: `gameId` in the resource method, the request, and the exception message.

Verified end to end against the live endpoint with a deliberately invalid key — 311 achievements for app `381210`, and `403` mapping to the right exception — which also confirms the key really is stripped.

Closes #50
