### PR TITLE
Docs pass for 0.6.0

### DIFF
--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -12,8 +12,9 @@ same arguments. Every argument that identifies a user is a
 documented in [Data objects](/php-steam-api-sdk/dto-reference).
 
 Badges list what a request throws on its own. On top of that, any request can raise
-`InvalidApiKeyException`, `SteamRateLimitException` or `SteamApiException` from the
-connector — see [Exceptions](/php-steam-api-sdk/guide#exceptions).
+`SteamRateLimitException` or `SteamApiException` from the connector, and every request
+that carries a key can raise `InvalidApiKeyException` — see
+[Exceptions](/php-steam-api-sdk/guide#exceptions).
 
 Both layers are namespaced by the Steam interface they belong to — one resource per
 interface, and one request class per endpoint:
@@ -156,9 +157,10 @@ new GetGlobalAchievementPercentagesForAppRequest($gameId)
 <p><Badge text="ISteamUserStats" variant="note" size="small" />{' '}<Badge text="throws StatsUnavailableException" variant="danger" size="small" /></p>
 
 How much of the playerbase has unlocked each achievement in a game, ordered from the most
-common down. Steam serves it anonymously, so the SDK keeps the configured key out of this
-one query. The exception covers two causes — a game carrying no achievements, or a game ID
-Steam does not know — because both answer identically.
+common down. Steam serves it anonymously, so the SDK strips the configured key from the
+query, and no key error can land here. Every `403` is about the game, and covers two
+causes — a game carrying no achievements, or a game ID Steam does not know — because both
+answer identically.
 
 ```php
 $achievements = $connector->stats()->globalAchievements(381210);
@@ -185,7 +187,7 @@ new GetNumberOfCurrentPlayersRequest($appId)
 <p><Badge text="ISteamUserStats" variant="note" size="small" />{' '}<Badge text="throws AppNotFoundException" variant="danger" size="small" /></p>
 
 How many people are playing a game right now, as a plain `int` rather than a DTO. Steam
-serves it anonymously, so the SDK keeps the configured key out of this one query.
+serves it anonymously, so the SDK strips the configured key from the query.
 
 ```php
 $players = $connector->stats()->currentPlayers(381210);

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: Configure the SteamConnector through the readonly SteamConfig — the API key, the rate-limit store, and how the daily quota is enforced across processes.
+description: Configure the SteamConnector through the readonly SteamConfig — the API key, the default language, the rate-limit store, and the daily quota across processes.
 ---
 
 import { Aside, Steps, Tabs, TabItem } from '@astrojs/starlight/components';
@@ -37,7 +37,8 @@ needs at runtime lives on that object.
 </Steps>
 
 The key is appended to every request as the `key` query parameter, so you never pass it
-per call.
+per call. Two endpoints Steam serves anonymously — `GetNumberOfCurrentPlayers` and
+`GetGlobalAchievementPercentagesForApp` — go out with it stripped back off.
 
 ## SteamConfig options
 
@@ -54,8 +55,8 @@ new connector.
 
 ## Default language
 
-Steam localises achievement names and descriptions through the `l` query parameter. Set it
-once on the config rather than on every call:
+Steam localises the achievement and stat names it sends back through the `l` query
+parameter. Set it once on the config rather than on every call:
 
 ```php title="steam.php" "language: Language::Polish"
 use Fkrzski\SteamApiSdk\Enums\Language;

--- a/docs/guide.mdx
+++ b/docs/guide.mdx
@@ -183,11 +183,13 @@ from a rejected one, so everywhere else it surfaces as rejected. A JSON `400` on
 `400` means nothing but an app ID Steam does not know, so it is the one that raises
 `AppNotFoundException` from that status.
 
-<Aside type="caution" title="Three endpoints answer ambiguously">
-`GetPlayerAchievements` returns a byte-identical `Requested app has no stats` body for an
-app without achievements and for a private profile. `GetRecentlyPlayedGames` and
-`GetCommunityBadgeProgress` return an empty payload both for a hidden profile and for a
-SteamID64 that belongs to no account. Every message names every cause rather than guessing.
+<Aside type="caution" title="Four endpoints answer ambiguously">
+`GetPlayerAchievements` returns a byte-identical `Requested app has no stats` body for an app
+without achievements and for a private profile, and `GetGlobalAchievementPercentagesForApp`
+answers the same `403` for a game carrying no achievements and for a game ID Steam does not
+know. `GetRecentlyPlayedGames` and `GetCommunityBadgeProgress` return an empty payload both
+for a hidden profile and for a SteamID64 that belongs to no account. Every message names
+every cause rather than guessing.
 </Aside>
 
 ## Testing


### PR DESCRIPTION
## Summary

Corrects four cross-cutting statements the per-endpoint docs of 0.6.0 left behind.

- `configuration.mdx` — the key is no longer appended to *every* request: `GetNumberOfCurrentPlayers` and `GetGlobalAchievementPercentagesForApp` go out with it stripped. The page description and the default-language intro cover `language` and localised stat names too.
- `api-reference.mdx` — `InvalidApiKeyException` is scoped to requests that carry a key, and the two anonymous endpoints no longer each claim to be the only one.
- `guide.mdx` — the ambiguous-response aside counts four endpoints, not three: `GetGlobalAchievementPercentagesForApp` answers the same `403` for a game carrying no achievements and for a game ID Steam does not know.

## Why

Every 0.6.0 feature PR carried its own `docs:` commit, so the new endpoints, their DTOs and the `Language` enum were documented as they landed. What no single PR touched are the sentences that quantify over the whole SDK — they were written before anonymous endpoints and a fourth ambiguous response existed, and they now describe behaviour the code does not have.

No headings changed, so the anchors other projects link to are untouched.

Closes #51
