### PR TITLE
Prepare 0.6.0 release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: SDK version
       description: Output of `composer show fkrzski/php-steam-api-sdk` (or commit SHA if installed from source).
-      placeholder: "0.5.0"
+      placeholder: "0.6.0"
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-09-01
+
 ### Added
 
 - `AppNotFoundException` for an app ID Steam does not know, thrown only where the response separates it from an app that merely exposes no stats. The `400` on `GetPlayerAchievementsRequest` does not, so it keeps `StatsUnavailableException` ([#47](https://github.com/fkrzski/php-steam-api-sdk/issues/47)).
@@ -109,7 +111,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enums: `PersonaState`, `CommunityVisibility`, `CommentPermission`.
 - Test suite (Pest) with Saloon `MockClient` fixtures, PHPStan max, 100% type coverage, Pint and Rector.
 
-[Unreleased]: https://github.com/fkrzski/php-steam-api-sdk/compare/0.5.0...HEAD
+[Unreleased]: https://github.com/fkrzski/php-steam-api-sdk/compare/0.6.0...HEAD
+[0.6.0]: https://github.com/fkrzski/php-steam-api-sdk/releases/tag/0.6.0
 [0.5.0]: https://github.com/fkrzski/php-steam-api-sdk/releases/tag/0.5.0
 [0.4.0]: https://github.com/fkrzski/php-steam-api-sdk/releases/tag/0.4.0
 [0.3.0]: https://github.com/fkrzski/php-steam-api-sdk/releases/tag/0.3.0


### PR DESCRIPTION
## Summary

Cuts `Unreleased` to `[0.6.0] - 2026-09-01` with its link definitions, and bumps the SDK version placeholder in the bug report template.

## Why

Stacked on #56 so the docs corrections land before the release is cut — retarget to `master` once that one merges.

The `Unreleased` entries were already complete, each feature PR having added its own, so this is the cut and nothing else. Release contents: `GetSchemaForGameRequest`, `GetGlobalAchievementPercentagesForAppRequest` and `GetNumberOfCurrentPlayersRequest` close out `ISteamUserStats`, alongside the `Language` enum and its `SteamConfig` default.

**BC break.** `$language` is a `?Language` instead of a `?string` on `GetPlayerAchievementsRequest`, `GetUserStatsForGameRequest` and both `StatsResource` methods. Callers passing a raw code swap `'english'` for `Language::English` (#46).
